### PR TITLE
Allow context-insensitive translation matching

### DIFF
--- a/Gettext/Translation.php
+++ b/Gettext/Translation.php
@@ -17,7 +17,9 @@ class Translation {
 	}
 
 	public function is ($context = false, $original = null, $plural = null) {
-		return (($context === false || $this->context === $context) && ($this->original === $original) && ($this->plural === $plural)) ? true : false;
+		return (($context === false || $this->context === $context)
+			&& ($this->original === $original)
+			&& ($this->plural === $plural)) ? true : false;
 	}
 
 	//ORIGINAL STRING


### PR DESCRIPTION
Allows finding of translation strings in a context-independent way. Calling Translation::is() (hence Entries::find()) with $context argument set to false will ignore context upon matching.
