### PR TITLE
Added method to wipe references & bugfix

### DIFF
--- a/Gettext/Entries.php
+++ b/Gettext/Entries.php
@@ -37,7 +37,7 @@ class Entries extends \ArrayObject {
 			$original = $original->getOriginal();
 			$plural = $original->getPlural();
 		} else {
-			$context = (string)$context;
+			$context = ($context === null) ? null : (string)$context;
 			$original = (string)$original;
 			$plural = (string)$plural;
 		}

--- a/Gettext/Translation.php
+++ b/Gettext/Translation.php
@@ -101,7 +101,9 @@ class Translation {
 	public function hasReferences () {
 		return isset($this->references[0]);
 	}
-
+    public function wipeReferences () {
+    	$this->references = array();
+    }
 	public function getReferences () {
 		return $this->references;
 	}


### PR DESCRIPTION
Bug: Find entry when subject context is null, converts context to string, then strict-compares, thus never finds matches.
Fix: don't convert type to string if $context is null.

Method added to wipe references from translation.
