### PR TITLE
Bugfix: last entry in PO was never loaded (Extractor/PO)

### DIFF
--- a/Gettext/Extractors/Po.php
+++ b/Gettext/Extractors/Po.php
@@ -35,7 +35,6 @@ class Po extends Extractor {
 			}
 			list($key, $data) = preg_split('/\s/', $line, 2);
 			$append = null;
-
 			switch ($key) {
 				case '#,':
 				case '#':
@@ -98,6 +97,9 @@ class Po extends Extractor {
 					}
 					break;
 			}
+		}
+		if ($translation->hasOriginal() && !in_array($translation, iterator_to_array($entries))) {
+			$entries[] = $translation;
 		}
 		return $entries;
 	}


### PR DESCRIPTION
Hello again, =)

Bug: If we are pushing Translation of former iteration onto Entries array on current iteration, the very last Translation will never be pushed.

Fix: after loop, we push the latest Translation onto the array.
