### PR TITLE
Extract translations from function params #10

### DIFF
--- a/Gettext/Extractors/PhpCode.php
+++ b/Gettext/Extractors/PhpCode.php
@@ -41,7 +41,7 @@ class PhpCode extends Extractor {
 				continue;
 			}
 
-			if (!$currentFunction && ($value[0] === T_STRING) && is_string($tokens[$k + 1]) && ($tokens[$k + 1] === '(')) {
+			if (($value[0] === T_STRING) && is_string($tokens[$k + 1]) && ($tokens[$k + 1] === '(')) {
 				$currentFunction = array($value[1], $value[2]);
 				continue;
 			}


### PR DESCRIPTION
There is a problem extracting translation functions when they are used as params of other

```
foo(array('bar' => __('Array VALUE')));
```

https://github.com/oscarotero/Gettext/issues/10
