### PR TITLE
Wrong empty line skipping logic in .po extractor

### DIFF
--- a/Gettext/Extractors/Po.php
+++ b/Gettext/Extractors/Po.php
@@ -27,10 +27,11 @@ class Po extends Extractor {
 
 			$line = self::fixMultiLines($line,$lines,$i);
 
-			if ($line === '' && $translation->hasOriginal()) {
-				$entries[] = $translation;
-
-				$translation = new Translation;
+			if ($line === '') {
+				if($translation->hasOriginal()) {
+					$entries[] = $translation;
+					$translation = new Translation;
+				}
 				continue;
 			}
 			list($key, $data) = preg_split('/\s/', $line, 2);


### PR DESCRIPTION
Raised at least in case when file contains empty line at the end. But problem actual when empty lines located anywhere in .po file.
