### PR TITLE
fixed function name at Gettext\Extractors\Po

### DIFF
--- a/Gettext/Extractors/Po.php
+++ b/Gettext/Extractors/Po.php
@@ -80,7 +80,7 @@ class Po extends Extractor {
 
 				default:
 					if (strpos($key, 'msgstr[') === 0) {
-						$translation->addPluralTranslation(self::clean($data));
+						$translation->setPluralTranslation(self::clean($data));
 						$append = 'PluralTranslation';
 						break;
 					}


### PR DESCRIPTION
there's no function named `addPluralTranslation` on `Gettext\Translation` class, so I assume it's a typo. this patch fixes a fatal error when using `Gettext\Extractors\Po` extractor.
