### PR TITLE
Fixed Entries::mergeWith with method MERGE_REMOVE

### DIFF
--- a/Gettext/Entries.php
+++ b/Gettext/Entries.php
@@ -200,9 +200,11 @@ class Entries extends \ArrayObject
         }
 
         if ($method & self::MERGE_REMOVE) {
-            foreach ($this as $k => $entry) {
+            $iterator = $this->getIterator();
+            
+            foreach ($iterator as $k => $entry) {
                 if (!($existing = $entries->find($entry))) {
-                    unset($this[$k]);
+                    $iterator->offsetUnset($k);
                 }
             }
         }


### PR DESCRIPTION
It was throwing an `ArrayIterator::next(): Array was modified outside object and internal position is no longer valid` error
