### PR TITLE
Avoid warning while reading an empty file

### DIFF
--- a/src/Extractors/Extractor.php
+++ b/src/Extractors/Extractor.php
@@ -81,7 +81,7 @@ abstract class Extractor
             throw new Exception("Cannot read the file '$file', probably permissions");
         }
 
-        $content = fread($fd, $length);
+        $content = $length ? fread($fd, $length) : '';
         fclose($fd);
 
         return $content;


### PR DESCRIPTION
When reading an empty file, fread throws this warning:
`Warning: fread(): Length parameter must be greater than 0 in ...Extractors/Extractor.php on line 84`

Let's fix this :wink: