### PR TITLE
Mo genetation stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ php:
   - 5.5
   - 5.4
   - 5.3
-script: phpunit tests
+script: phpunit

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit>
+	<testsuites>
+		<testsuite name="All tests">
+			<directory>./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/src/Extractors/Mo.php
+++ b/src/Extractors/Mo.php
@@ -67,6 +67,8 @@ class Mo extends Extractor implements ExtractorInterface
                 $translation->setPluralTranslation($pluralTranslation);
             }
         }
+
+        return $translations;
     }
 
     /**

--- a/src/Generators/Mo.php
+++ b/src/Generators/Mo.php
@@ -37,7 +37,7 @@ class Mo extends Generator implements GeneratorInterface
 
             //Plural msgstrs are NUL-separated
             $msgstrs = array_merge(array($translation->getTranslation()), $translation->getPluralTranslation());
-            $str = str_replace("\n", "\x00", implode("\x00", $msgstrs));
+            $str = implode("\x00", $msgstrs);
 
             $offsets[] = array(strlen($ids), strlen($id), strlen($strings), strlen($str));
 

--- a/src/Generators/Mo.php
+++ b/src/Generators/Mo.php
@@ -14,7 +14,15 @@ class Mo extends Generator implements GeneratorInterface
 
         foreach ($translations as $translation) {
             if ($translation->hasTranslation()) {
-                $array[$translation->getOriginal()] = $translation;
+                $id = '';
+                if ($translation->hasContext()) {
+                    $id .= $translation->getContext()."\x04";
+                }
+                $id .= $translation->getOriginal();
+                if ($translation->hasPlural()) {
+                    $id .= "\x00".$translation->getPlural();
+                }
+                $array[$id] = $translation;
             }
         }
 
@@ -24,17 +32,7 @@ class Mo extends Generator implements GeneratorInterface
         $ids = '';
         $strings = '';
 
-        foreach ($array as $translation) {
-            $id = $translation->getOriginal();
-
-            if ($translation->hasPlural()) {
-                $id .= "\x00".$translation->getPlural();
-            }
-
-            if ($translation->hasContext()) {
-                $id = $translation->getContext()."\x04".$id;
-            }
-
+        foreach ($array as $id => $translation) {
             //Plural msgstrs are NUL-separated
             $msgstrs = array_merge(array($translation->getTranslation()), $translation->getPluralTranslation());
             $str = implode("\x00", $msgstrs);

--- a/tests/MoGenerationTest.php
+++ b/tests/MoGenerationTest.php
@@ -1,0 +1,25 @@
+<?php
+include_once dirname(__DIR__).'/src/autoloader.php';
+
+class MoGenerationTest extends PHPUnit_Framework_TestCase
+{
+    public function testMoGeneration()
+    {
+        $originalTranslations = Gettext\Translations::fromPoFile(__DIR__.'/files/po.po');
+        $this->assertInstanceOf('Gettext\\Translations', $originalTranslations);
+
+        $moData = $originalTranslations->toMoString();
+        $this->assertInternalType('string', $moData);
+        $this->assertGreaterThan(0, strlen($moData));
+
+        $decompiledTranslations = Gettext\Translations::fromMoString($moData);
+        $this->assertInstanceOf('Gettext\\Translations', $decompiledTranslations);
+        
+        $this->assertSame($originalTranslations->count(), $decompiledTranslations->count());
+
+        foreach ($originalTranslations as $originalTranslation) {
+            $decompiledTranslation = $decompiledTranslations->find($originalTranslation->getContext(), $originalTranslation->getOriginal());
+            $this->assertInstanceOf('Gettext\\Translation', $decompiledTranslation, 'Translation not found: context="'.$originalTranslation->getContext().'", original="'.$originalTranslation->getOriginal().'"');
+        }
+    }
+}


### PR DESCRIPTION
- Add a phpunit.xml file so that tests can be run with `phpunit` instead of `phpunit tests`
- Fix `Extractors\Mo::fromString` so that it returns the newly created stuff (`Gettext\Translations::fromMoString('...');` always returns null otherwise)
- Add a test to check the generated .mo data.

Please note that this new test **will fail**, denoting that the .mo generation is broken.
I'll update this PR to add some fixes.