### PR TITLE
Add methods to create Translations with different plural rules

### DIFF
--- a/src/Translation.php
+++ b/src/Translation.php
@@ -364,4 +364,28 @@ class Translation
             $this->flags = array_values(array_unique(array_merge($translation->getFlags(), $this->flags)));
         }
     }
+
+    /**
+     * Changes the plural count of this translation. Please remark that partial plural translations will be emptied.
+     * @param int $plurals
+     */
+    public function setPluralCount($nplurals)
+    {
+        if ($this->hasPlural()) {
+            $newArraySize = $nplurals - 1;
+            if ($newArraySize < 1) {
+                $this->pluralTranslation = array();
+            } else {
+                $oldArraySize = count($this->pluralTranslation);
+                if ($newArraySize < $oldArraySize) {
+                    $this->pluralTranslation = array_slice($this->pluralTranslation, 0, $newArraySize);
+                } elseif ($newArraySize > $oldArraySize) {
+                    $this->translation = '';
+                    $this->pluralTranslation = array_fill(0, $newArraySize, '');
+                }
+            }
+        } else {
+            $this->pluralTranslation = array();
+        }
+    }
 }

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -235,4 +235,15 @@ class Translations extends \ArrayObject
             $this->exchangeArray($filtered);
         }
     }
+
+    /**
+     * Changes the plural count of all the translations. Please remark that partial plural translations will be emptied.
+     * @param int $plurals
+     */
+    public function setPluralCount($nplurals)
+    {
+        foreach ($this as $t) {
+            $t->setPluralCount($nplurals);
+        }
+    }
 }


### PR DESCRIPTION
gettext/gettext currently can extracts strings from source files, thus creating an dictionary of translations (in GNU-gettext terms it may be seen as a POT - Portable Object Template - file).

When creating translations for other languages, we may need to change the plural count of the translations. So, let's introduce this new `setPluralCount` method.

For instance, here's a whole process to create two translation (.po) files, one for Russian (3 plural rules) and one for Japanese (1 plural rule):
```php
$pot = \Gettext\Translations::fromPhpCodeFile($file);
$ruPo = clone $pot;
$ruPo->setPluralCount(3);
$jaPo = clone $pot;
$jaPo->setPluralCount(1);
```