### PR TITLE
Allow getLocaleInfo to accept variants

### DIFF
--- a/src/Utils/Locales.php
+++ b/src/Utils/Locales.php
@@ -161,7 +161,7 @@ class Locales
     {
         $result = null;
         // Locale identifier structure: see Unicode Language Identifier - http://www.unicode.org/reports/tr35/tr35-31/tr35.html#Unicode_language_identifier
-        if (is_string($code) && preg_match($code, '/^([a-z]{2,3})(?:[_\-]([a-z]{4}))?(?:[_\-]([a-z]{2}|[0-9]{3}))?(?:$|[_\-])/i', $matches)) {
+        if (is_string($code) && preg_match('/^([a-z]{2,3})(?:[_\-]([a-z]{4}))?(?:[_\-]([a-z]{2}|[0-9]{3}))?(?:$|[_\-])/i', $code, $matches)) {
             $language = strtolower($matches[1]);
             $script = isset($matches[2]) ? ucfirst(strtolower($matches[2])) : '';
             $territory = isset($matches[3]) ? strtoupper($matches[3]) : '';

--- a/src/Utils/Locales.php
+++ b/src/Utils/Locales.php
@@ -152,13 +152,39 @@ class Locales
 
     /**
      * Returns the info of a locale
-     * 
+     *
      * @param string $code
-     * 
+     *
      * @return null|array
      */
     public static function getLocaleInfo($code)
     {
-        return isset(self::$localeInfo[$code]) ? self::$localeInfo[$code] : null;
+        $result = null;
+        // Locale identifier structure: see Unicode Language Identifier - http://www.unicode.org/reports/tr35/tr35-31/tr35.html#Unicode_language_identifier
+        if (is_string($code) && preg_match($code, '/^([a-z]{2,3})(?:[_\-]([a-z]{4}))?(?:[_\-]([a-z]{2}|[0-9]{3}))?(?:$|[_\-])/i', $matches)) {
+            $language = strtolower($matches[1]);
+            $script = isset($matches[2]) ? ucfirst(strtolower($matches[2])) : '';
+            $territory = isset($matches[3]) ? strtoupper($matches[3]) : '';
+            // Structure precedence: see Likely Subtags - http://www.unicode.org/reports/tr35/tr35-31/tr35.html#Likely_Subtags
+            $variants = array();
+            if (strlen($script) && strlen($territory)) {
+                $variants[] = "{$language}_{$script}_{$territory}";
+            }
+            if (strlen($script)) {
+                $variants[] = "{$language}_{$script}";
+            }
+            if (strlen($territory)) {
+                $variants[] = "{$language}_{$territory}";
+            }
+            $variants[] = $language;
+            foreach ($variants as $variant) {
+                if (isset(static::$localeInfo[$variant])) {
+                    $result = static::$localeInfo[$variant];
+                    break;
+                }
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/Utils/Locales.php
+++ b/src/Utils/Locales.php
@@ -3,7 +3,11 @@ namespace Gettext\Utils;
 
 class Locales
 {
-    // Data from https://github.com/mlocati/concrete5-translation-library/blob/41abcdba30631ff42711aa82479dc505452e3725/src/Gettext.php#L109
+    /**
+     * Language definitions
+     * @var array
+     * @link http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html
+     */
     protected static $localeInfo = array(
         'ach' => array('name' => 'Acholi', 'plurals' => 2, 'pluralRule' => '(n > 1)'),
         'af' => array('name' => 'Afrikaans', 'plurals' => 2, 'pluralRule' => '(n != 1)'),


### PR DESCRIPTION
Allow getLocaleInfo to be called with a complex locale identifier.
As for the Unicode specs, locale identifiers may be composed by:
- language code (2 to 3 letters)
- script (4 letters)
- territory (2 letters or 3 numbers)

This PR parses the locale code and extract the language code (mandatory), the script (optional) and the territory (optional).
So, it can accept codes like
- `'it'`
- `'it_IT'`
- `'it_Latn'`
- `'it_Latn_IT'`