### PR TITLE
Faster extraction

### DIFF
--- a/src/Extractors/Blade.php
+++ b/src/Extractors/Blade.php
@@ -13,10 +13,11 @@ class Blade extends Extractor implements ExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public static function fromString($string, Translations $translations = null, $file = '')
+    protected static function fromStringDo($string, Translations $translations, $file)
     {
-        $string = (new BladeCompiler(new Filesystem(), null))->compileString($string);
+        $bladeCompiler = new BladeCompiler(new Filesystem(), null);
+        $string = $bladeCompiler->compileString($string);
 
-        return PhpCode::fromString($string, $translations, $file);
+        PhpCode::fromString($string, $translations, $file);
     }
 }

--- a/src/Extractors/Extractor.php
+++ b/src/Extractors/Extractor.php
@@ -27,7 +27,7 @@ abstract class Extractor
             $translations = new Translations();
         }
         $originalSIC = $translations->getSkipIntegrityChecks();
-        if (self::$skipIntegrityChecksOnImport) {
+        if (static::$skipIntegrityChecksOnImport) {
             $translations->setSkipIntegrityChecks(true);
         }
         try {
@@ -62,7 +62,7 @@ abstract class Extractor
             $translations = new Translations();
         }
         $originalSIC = $translations->getSkipIntegrityChecks();
-        if (self::$skipIntegrityChecksOnImport) {
+        if (static::$skipIntegrityChecksOnImport) {
             $translations->setSkipIntegrityChecks(true);
         }
         try {

--- a/src/Extractors/Extractor.php
+++ b/src/Extractors/Extractor.php
@@ -8,6 +8,12 @@ use Gettext\Translations;
 abstract class Extractor
 {
     /**
+     * Set to true if integrity checks should be skipped diring the import process, false otherwise
+     * @var bool
+     */
+    public static $skipIntegrityChecksOnImport = false;
+
+    /**
      * Extract the translations from a file
      *
      * @param array|string      $file         A path of a file or files
@@ -20,12 +26,59 @@ abstract class Extractor
         if ($translations === null) {
             $translations = new Translations();
         }
+        $originalSIC = $translations->getSkipIntegrityChecks();
+        if (self::$skipIntegrityChecksOnImport) {
+            $translations->setSkipIntegrityChecks(true);
+        }
+        try {
+            static::fromFileDo($file, $translations);
+        } catch (Exception $x) {
+            $translations->setSkipIntegrityChecks($originalSIC);
+            throw $x;
+        }
+        $translations->setSkipIntegrityChecks($originalSIC);
 
+        return $translations;
+    }
+
+    protected static function fromFileDo($file, Translations $translations)
+    {
         foreach (self::getFiles($file) as $file) {
             static::fromString(self::readFile($file), $translations, $file);
         }
+    }
+
+    /**
+     * Extract the translations from a string
+     * @param string $string
+     * @param null|Translations $translations The translations instance to append the new translations.
+     * @param string $file A path of a file
+     *
+     * @return Translations
+     */
+    final public static function fromString($string, Translations $translations = null, $file = '')
+    {
+        if ($translations === null) {
+            $translations = new Translations();
+        }
+        $originalSIC = $translations->getSkipIntegrityChecks();
+        if (self::$skipIntegrityChecksOnImport) {
+            $translations->setSkipIntegrityChecks(true);
+        }
+        try {
+            static::fromStringDo($string, $translations, $file);
+        } catch (Exception $x) {
+            $translations->setSkipIntegrityChecks($originalSIC);
+            throw $x;
+        }
+        $translations->setSkipIntegrityChecks($originalSIC);
 
         return $translations;
+    }
+
+    protected static function fromStringDo($string, Translations $translations, $file)
+    {
+        throw new Exception('fromStringDo Not implemented');
     }
 
     /**

--- a/src/Extractors/Jed.php
+++ b/src/Extractors/Jed.php
@@ -11,14 +11,10 @@ class Jed extends PhpArray implements ExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public static function fromString($string, Translations $translations = null, $file = '')
+    protected static function fromStringDo($string, Translations $translations, $file)
     {
-        if ($translations === null) {
-            $translations = new Translations();
-        }
-
         $content = json_decode($string);
 
-        return PhpArray::handleArray($content, $translations);
+        PhpArray::handleArray($content, $translations);
     }
 }

--- a/src/Extractors/JsCode.php
+++ b/src/Extractors/JsCode.php
@@ -18,12 +18,8 @@ class JsCode extends Extractor implements ExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public static function fromString($string, Translations $translations = null, $file = '')
+    protected static function fromStringDo($string, Translations $translations, $file)
     {
-        if ($translations === null) {
-            $translations = new Translations();
-        }
-
         $functions = new JsFunctionsScanner($string);
         $functions->saveGettextFunctions(self::$functions, $translations, $file);
     }

--- a/src/Extractors/Mo.php
+++ b/src/Extractors/Mo.php
@@ -17,12 +17,8 @@ class Mo extends Extractor implements ExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public static function fromString($string, Translations $translations = null, $file = '')
+    protected static function fromStringDo($string, Translations $translations, $file)
     {
-        if ($translations === null) {
-            $translations = new Translations();
-        }
-
         $stream = new StringReader($string);
         $magic = self::readInt($stream, 'V');
 
@@ -95,8 +91,6 @@ class Mo extends Extractor implements ExtractorInterface
                 }
             }
         }
-
-        return $translations;
     }
 
     /**

--- a/src/Extractors/Mo.php
+++ b/src/Extractors/Mo.php
@@ -10,6 +10,12 @@ use Gettext\Utils\StringReader;
 
 class Mo extends Extractor implements ExtractorInterface
 {
+    /**
+     * Set to true if integrity checks should be skipped diring the import process, false otherwise
+     * @var bool
+     */
+    public static $skipIntegrityChecksOnImport = true;
+
     const MAGIC1 = -1794895138;
     const MAGIC2 = -569244523;
     const MAGIC3 = 2500072158;

--- a/src/Extractors/PhpArray.php
+++ b/src/Extractors/PhpArray.php
@@ -17,23 +17,17 @@ class PhpArray extends Extractor implements ExtractorInterface
      *
      * @return Translations
      */
-    public static function fromFile($file, Translations $translations = null)
+    protected static function fromFileDo($file, Translations $translations)
     {
-        if ($translations === null) {
-            $translations = new Translations();
-        }
-
         foreach (self::getFiles($file) as $file) {
             self::handleArray(include($file), $translations);
         }
-
-        return $translations;
     }
 
     /**
      * {@inheritDoc}
      */
-    public static function fromString($string, Translations $translations = null, $file = '')
+    protected static function fromStringDo($string, Translations $translations, $file)
     {
         throw new Exception("PhpArray::fromString() cannot be called. Use PhpArray::fromFile()");
     }

--- a/src/Extractors/PhpCode.php
+++ b/src/Extractors/PhpCode.php
@@ -21,12 +21,8 @@ class PhpCode extends Extractor implements ExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public static function fromString($string, Translations $translations = null, $file = '')
+    protected static function fromStringDo($string, Translations $translations, $file)
     {
-        if ($translations === null) {
-            $translations = new Translations();
-        }
-
         $functions = new PhpFunctionsScanner($string);
         $functions->saveGettextFunctions(self::$functions, $translations, $file);
     }

--- a/src/Extractors/Po.php
+++ b/src/Extractors/Po.php
@@ -14,12 +14,8 @@ class Po extends Extractor implements ExtractorInterface
      *
      * {@inheritDoc}
      */
-    public static function fromString($string, Translations $translations = null, $file = '')
+    protected static function fromStringDo($string, Translations $translations, $file)
     {
-        if ($translations === null) {
-            $translations = new Translations();
-        }
-
         $lines = explode("\n", $string);
         $i = 1;
         $currentHeader = null;
@@ -135,8 +131,6 @@ class Po extends Extractor implements ExtractorInterface
         if ($translation->hasOriginal() && !in_array($translation, iterator_to_array($translations))) {
             $translations[] = $translation;
         }
-
-        return $translations;
     }
 
     /**

--- a/src/Extractors/Po.php
+++ b/src/Extractors/Po.php
@@ -10,6 +10,12 @@ use Gettext\Translation;
 class Po extends Extractor implements ExtractorInterface
 {
     /**
+     * Set to true if integrity checks should be skipped diring the import process, false otherwise
+     * @var bool
+     */
+    public static $skipIntegrityChecksOnImport = true;
+
+    /**
      * Parses a .po file and append the translations found in the Translations instance
      *
      * {@inheritDoc}

--- a/tests/PoExtractorTest.php
+++ b/tests/PoExtractorTest.php
@@ -93,6 +93,7 @@ class PoExtractorTest extends PHPUnit_Framework_TestCase
 
     public function testDuplicates()
     {
+        Gettext\Extractors\Po::$skipIntegrityChecksOnImport = false;
         $translations = Gettext\Extractors\Po::fromFile(__DIR__.'/files/duplicate.po');
 
         //duplicate singular


### PR DESCRIPTION
When adding string to the `Translations` instance, we call [`Translations::offsetSet`](https://github.com/oscarotero/Gettext/blob/v3.0/src/Translations.php#L100-L118) that in turns calls [`Translation:is`](https://github.com/oscarotero/Gettext/blob/v3.0/src/Translations.php#L303-L307) many times.
If we load 5.000 strings, its inner cycle calls `Translation:is` 12.497.500 times (5000\*(5000-1)/2).
What about adding an option to skip this check?

With the code of this pull request, the checks are skipped by default for the .po and .mo importers (but it's configurable by writing `Gettext\Extractors\Mo::$skipIntegrityChecksOnImport`.