### PR TITLE
Remove development stuff from downloadable archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/tests/ export-ignore
+/.travis.yml export-ignore
+/phpunit.xml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 /tests/ export-ignore
-/.travis.yml export-ignore
 /phpunit.xml export-ignore
+.* export-ignore


### PR DESCRIPTION
With this change, the archives downloaded from https://github.com/oscarotero/Gettext/releases don't contain development stuff