### PR TITLE
Fix mo file generation

### DIFF
--- a/src/Generators/Mo.php
+++ b/src/Generators/Mo.php
@@ -22,6 +22,7 @@ class Mo extends Generator implements GeneratorInterface
         }
 
         foreach ($translations as $translation) {
+            if (!$translation->hasTranslation()) continue;
             if ($translation->hasContext()) {
                 $originalString = $translation->getContext()."\x04".$translation->getOriginal();
             } else {


### PR DESCRIPTION
Hi,
I just started using this library in one of my applications and everything worked great until I generated the final mo file. It seems that the way it currently works it will generate empty strings for all non translated strings in the mo file. Skipping the untranslated translations seems to fix this and it appears to be what PoEdit is doing. I compared file sizes when using PoEdit and when generating with the Gettext library and they appear to be about the same now with this fix.