### PR TITLE
Avoid adding empty strings

### DIFF
--- a/src/Utils/FunctionsScanner.php
+++ b/src/Utils/FunctionsScanner.php
@@ -35,7 +35,9 @@ abstract class FunctionsScanner
                         continue 2;
                     }
                     $original = $args[0];
-                    $translation = $translations->insert('', $original);
+                    if ($original !== '') {
+                        $translation = $translations->insert('', $original);
+                    }
                     break;
 
                 case 'n__':
@@ -44,7 +46,9 @@ abstract class FunctionsScanner
                     }
                     $original = $args[0];
                     $plural = $args[1];
-                    $translation = $translations->insert('', $original, $plural);
+                    if ($original !== '') {
+                        $translation = $translations->insert('', $original, $plural);
+                    }
                     break;
 
                 case 'p__':
@@ -53,7 +57,9 @@ abstract class FunctionsScanner
                     }
                     $context = $args[0];
                     $original = $args[1];
-                    $translation = $translations->insert($context, $original);
+                    if ($original !== '') {
+                        $translation = $translations->insert($context, $original);
+                    }
                     break;
 
                 default:


### PR DESCRIPTION
The PhpFunctionsScanner extracts empty strings too (eg `echo __('');`). So, we risk to generate a .po file like this:
```po
# PO headers
msgid ""
msgstr ""
"Header 1: value\n"
"Header 2: value\n"

# Empty string extracted from code
msgid ""
msgstr ""

...
```
This is wrong, since the msgid must be unique (and this specific case messes up the gettext headers).