### PR TITLE
What is the purpose of the 'glue' character on translation ids

### DIFF
--- a/tests/PoExtractorTest.php
+++ b/tests/PoExtractorTest.php
@@ -130,4 +130,13 @@ class PoExtractorTest extends PHPUnit_Framework_TestCase
         $t->setPluralTranslation('% estrelas');
         $this->assertTrue($t->hasPluralTranslation());
     }
+
+    public function testKeysAreClean()
+    {
+        $translations = Gettext\Extractors\Po::fromFile(__DIR__.'/files/no-headers.po');
+
+        $msgId = key($translations);
+        
+        $this->assertSame('Dielen', $msgId);
+    }
 }


### PR DESCRIPTION
This is a great library and has saved me loads of time in a project thank-you for creating it and maintaining it. 

The only problem / slight weirdness I have is that I must clean the unprinted glue character 0x04 off the beginning of every msgId before I use it. I have attached a test to show you what I mean.

I guess if you are going to use these hidden characters to indicate something they should be stripped on output but I don't really understand the purpose and removing it didn't fail any tests.

Thanks again.
