### PR TITLE
Update JsonDictionary.php

### DIFF
--- a/src/Generators/JsonDictionary.php
+++ b/src/Generators/JsonDictionary.php
@@ -24,7 +24,7 @@ class JsonDictionary extends Generator implements GeneratorInterface
         return json_encode(
             array_filter(
                 array_map(function ($val) {
-                    return $val[1];
+                    return isset($val[1]) ? $val[1] : null;
                 }, $values)
             )
         );


### PR DESCRIPTION
If PHP is set to strict mode, this will give an error sometimes with "Undefined offset of 1".  This checks the value before mapping it, which will remove the false value afterwards.