### PR TITLE
Added new js usage that break extractor test and asserts that catch it.

### DIFF
--- a/tests/JsCodeExtractorTest.php
+++ b/tests/JsCodeExtractorTest.php
@@ -6,14 +6,17 @@ class JsCodeExtractorTest extends PHPUnit_Framework_TestCase
     {
         //Extract translations
         $translations = Gettext\Extractors\JsCode::fromFile(__DIR__.'/files/jscode.js');
-
+        
         $this->assertInstanceOf('Gettext\\Translations', $translations);
 
-        $this->assertCount(4, $translations);
+        $this->assertCount(7, $translations);
 
         $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, 'Value with simple quotes'));
         $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, 'Value with double quotes'));
         $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, 'Other value with double quotes'));
         $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, 'function inside function'));
+        $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, 'I can\'t get response.'));
+        $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, 'Please, try with other interface type.'));
+        $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, 'I can\'t get response. Please, try with other interface type.'));
     }
 }

--- a/tests/files/jscode.js
+++ b/tests/files/jscode.js
@@ -7,4 +7,11 @@ $(document).ready(function () {
 
 	/* var value5 = __("Commented function, not valid");*/
 	// var value6 = __('Other commented function')
+        
+        var resp = __("I can't get response.");
+        resp += " " + __("Please, try with other interface type.");
+        
+        resp = '<div class="alert alert-danger">';
+        resp += __("I can't get response. Please, try with other interface type.");
+        resp += '</div>';
 });


### PR DESCRIPTION
Hi,

I'm using your library into Pharinix to manage translations, but I have problems when extract text from Javascript code. Some times not detect the translation functions, other get a incomplete string.

By this, I changed the JsCodeExtractorTest and the dummy js file to get the same error.

Thanks, I hope will be helpfull.