### PR TITLE
return translations object from PhpCode::fromString

### DIFF
--- a/src/Extractors/PhpCode.php
+++ b/src/Extractors/PhpCode.php
@@ -30,5 +30,7 @@ class PhpCode extends Extractor implements ExtractorInterface
 
         $functions = new PhpFunctionsScanner($string);
         $functions->saveGettextFunctions(self::$functions, $translations, $file);
+        
+        return $translations;
     }
 }


### PR DESCRIPTION
Use case:
//Scan the php code from a string to find the latest gettext translations
$translations = Translations::fromPhpCodeString($string2translate);

//Get the translations of the code that are stored in a po file
$poTranslations = Translations::fromPoFile('en.po');

//Apply the translations from the po file to the translations, and merges header and comments but not references and without add or remove translations:
$translations->mergeWith($poTranslations, Translations::MERGE_HEADERS | Translations::MERGE_COMMENTS);

//Now save a po file with the result
$translations->toPoFile('en_new.po');