### PR TITLE
Add test for some PHP special chars

### DIFF
--- a/tests/DecodePhpStringTest.php
+++ b/tests/DecodePhpStringTest.php
@@ -1,0 +1,32 @@
+<?php
+
+class DecodePhpStringTest extends PHPUnit_Framework_TestCase
+{
+    public function decodeStringsProvider()
+    {
+        return array(
+            array('"test"', 'test'),
+            array("'test'", 'test'),
+            array("'DATE \a\\t TIME'", 'DATE \a\t TIME'),
+            array("'DATE \a\\t TIME$'", 'DATE \a\t TIME$'),
+            array("'DATE \a\\t TIME\$'", 'DATE \a\t TIME$'),
+            array("'DATE \a\\t TIME\$a'", 'DATE \a\t TIME$a'),
+            array('"FIELD\\tFIELD"', "FIELD\tFIELD"),
+            array('"$"', '$'),
+            array('"Hi $"', 'Hi $'),
+            array('"$ hi"', '$ hi'),
+            array('"Hi\t$name"', "Hi\t\$name"),
+            array('"Hi\\\\"', 'Hi\\'),
+            array('"{$obj->name}"', '{$obj->name}'),
+            array('"a\x20b $c"', 'a b $c'),
+        );
+    }
+
+    /**
+     * @dataProvider decodeStringsProvider
+     */
+    public function testDecodeStrings($source, $decoded)
+    {
+        $this->assertSame($decoded, Gettext\Utils\PhpFunctionsScanner::decodeString($source));
+    }
+}

--- a/tests/PhpCodeExtractorTest.php
+++ b/tests/PhpCodeExtractorTest.php
@@ -60,4 +60,14 @@ EOT;
         $this->assertInstanceOf('Gettext\\Translation', $translation);
         $this->assertEquals($original, $translation->getOriginal());
     }
+
+    public function testSpecialChars()
+    {
+        $translations = Gettext\Extractors\PhpCode::fromFile(__DIR__.'/files/special-chars.php');
+
+        $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, 'plain'));
+        $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, 'DATE \\a\\t TIME'));
+        $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, "FIELD\tFIELD"));
+        $this->assertCount(3, $translations);
+    }
 }

--- a/tests/files/special-chars.php
+++ b/tests/files/special-chars.php
@@ -1,0 +1,7 @@
+<div>
+	<p><?php __('plain'); ?></p>
+    <p><?php __('DATE \a\t TIME'); ?></p>
+    <p><?php __("DATE \a\\t TIME"); ?></p>
+    <p><?php __("DATE \\a\\t TIME"); ?></p>
+    <p><?php __("FIELD\tFIELD"); ?></p>
+</div>


### PR DESCRIPTION
Let's consider this source code:
```php
<div>
	<p><?php __('plain'); ?></p>
    <p><?php __('DATE \a\t TIME'); ?></p>
    <p><?php __("DATE \a\\t TIME"); ?></p>
    <p><?php __("DATE \\a\\t TIME"); ?></p>
    <p><?php __("FIELD\tFIELD"); ?></p>
</div>
```

Here we have only 3 different strings, but the php extractor finds these strings:
```po
msgid "plain"
msgstr ""

msgid "DATE \\a\\t TIME"
msgstr ""

msgid "DATE \\a\\\\t TIME"
msgstr ""

msgid "DATE \\\\a\\\\t TIME"
msgstr ""

msgid "FIELD\\tFIELD"
msgstr ""
```