### PR TITLE
Disable composer warning about xdebug:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
 sudo: false
 
+env:
+  - COMPOSER_DISABLE_XDEBUG_WARN=1
+
 php:
   - 5.3
   - 5.4


### PR DESCRIPTION
In TravisCI you see this message:

```
You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug
```

Let's hide it :wink: