### PR TITLE
Extraction of variables and concatenated strings

### DIFF
--- a/src/Utils/ParsedFunction.php
+++ b/src/Utils/ParsedFunction.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Gettext\Utils;
+
+/**
+ * Function parsed by PhpFunctionsScanner.
+ */
+class ParsedFunction
+{
+    /**
+     * The function name.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The line where the function starts.
+     * 
+     * @var int
+     */
+    protected $line;
+
+    /**
+     * The strings extracted from the function arguments.
+     *
+     * @var string[]
+     */
+    protected $arguments;
+
+    /**
+     * The current index of the function (-1 if no arguments).
+     *
+     * @var int|null
+     */
+    protected $argumentIndex;
+
+    /**
+     * Shall we stop adding string chunks to the current argument?
+     *
+     * @var bool
+     */
+    protected $argumentStopped;
+
+    /**
+     * Initializes the instance.
+     *
+     * @param string $name The function name.
+     * @param int    $line The line where the function starts.
+     */
+    public function __construct($name, $line)
+    {
+        $this->name = $name;
+        $this->line = $line;
+        $this->arguments = array();
+        $this->argumentIndex = -1;
+        $this->argumentStopped = false;
+    }
+
+    /**
+     * Stop extracting strings from the current argument (because we found something that's not a string).
+     */
+    public function stopArgument()
+    {
+        if ($this->argumentIndex === -1) {
+            $this->argumentIndex = 0;
+        }
+        $this->argumentStopped = true;
+    }
+
+    /**
+     * Go to the next argument because we a comma was found.
+     */
+    public function nextArgument()
+    {
+        if ($this->argumentIndex === -1) {
+            // This should neve occur, but let's stay safe - During test/development an Exception should be thrown.
+            $this->argumentIndex = 1;
+        } else {
+            ++$this->argumentIndex;
+        }
+        $this->argumentStopped = false;
+    }
+
+    /**
+     * Add a string to the current argument.
+     *
+     * @param string $chunk
+     */
+    public function addArgumentChunk($chunk)
+    {
+        if ($this->argumentStopped === false) {
+            if ($this->argumentIndex === -1) {
+                $this->argumentIndex = 0;
+            }
+            if (isset($this->arguments[$this->argumentIndex])) {
+                $this->arguments[$this->argumentIndex] .= $chunk;
+            } else {
+                $this->arguments[$this->argumentIndex] = $chunk;
+            }
+        }
+    }
+
+    /**
+     * A closing parenthesis was found: return the final data.
+     *
+     * @return array{
+     *
+     *   @var string The function name.
+     *   @var int The line where the function starts.
+     *   @var string[] the strings extracted from the function arguments.
+     * }
+     */
+    public function close()
+    {
+        $arguments = array();
+        for ($i = 0; $i <= $this->argumentIndex; ++$i) {
+            $arguments[$i] = isset($this->arguments[$i]) ? $this->arguments[$i] : '';
+        }
+
+        return array(
+            $this->name,
+            $this->line,
+            $arguments,
+        );
+    }
+}

--- a/src/Utils/PhpFunctionsScanner.php
+++ b/src/Utils/PhpFunctionsScanner.php
@@ -46,9 +46,16 @@ class PhpFunctionsScanner extends FunctionsScanner
                     break;
                 case T_STRING:
                     //new function found
-                    if (is_string($this->tokens[$k + 1]) && ($this->tokens[$k + 1] === '(')) {
-                        array_unshift($bufferFunctions, array($value[1], $value[2], array()));
-                        ++$k;
+                    for ($j = $k + 1; $j < $count; $j++) {
+                        $nextToken = $this->tokens[$j];
+                        if (is_array($nextToken) && ($nextToken[0] === T_COMMENT || $nextToken[0] === T_WHITESPACE)) {
+                            continue;
+                        }
+                        if ($nextToken === '(') {
+                            array_unshift($bufferFunctions, array($value[1], $value[2], array()));
+                            $k = $j;
+                        }
+                        break;
                     }
                     break;
             }

--- a/src/Utils/PhpFunctionsScanner.php
+++ b/src/Utils/PhpFunctionsScanner.php
@@ -37,18 +37,20 @@ class PhpFunctionsScanner extends FunctionsScanner
                 continue;
             }
 
-            //add an argument to the current function
-            if (isset($bufferFunctions[0]) && ($value[0] === T_CONSTANT_ENCAPSED_STRING)) {
-                $bufferFunctions[0][2][] = \Gettext\Extractors\PhpCode::convertString($value[1]);
-                continue;
-            }
-
-            //new function found
-            if (($value[0] === T_STRING) && is_string($this->tokens[$k + 1]) && ($this->tokens[$k + 1] === '(')) {
-                array_unshift($bufferFunctions, array($value[1], $value[2], array()));
-                ++$k;
-
-                continue;
+            switch ($value[0]) {
+                case T_CONSTANT_ENCAPSED_STRING:
+                    //add an argument to the current function
+                    if (isset($bufferFunctions[0])) {
+                        $bufferFunctions[0][2][] = \Gettext\Extractors\PhpCode::convertString($value[1]);
+                    }
+                    break;
+                case T_STRING:
+                    //new function found
+                    if (is_string($this->tokens[$k + 1]) && ($this->tokens[$k + 1] === '(')) {
+                        array_unshift($bufferFunctions, array($value[1], $value[2], array()));
+                        ++$k;
+                    }
+                    break;
             }
         }
 

--- a/tests/PhpCodeExtractorTest.php
+++ b/tests/PhpCodeExtractorTest.php
@@ -68,6 +68,9 @@ EOT;
         $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, 'plain'));
         $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, 'DATE \\a\\t TIME'));
         $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, "FIELD\tFIELD"));
-        $this->assertCount(3, $translations);
+        $this->assertFalse($translations->find(null, "text "));
+        $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, "text concatenated with 'comments'"));
+        $this->assertInstanceOf('Gettext\\Translation', $translations->find(null, "Stop at the variable"));
+        $this->assertCount(5, $translations);
     }
 }

--- a/tests/files/special-chars.php
+++ b/tests/files/special-chars.php
@@ -1,7 +1,15 @@
 <div>
-	<p><?php __('plain'); ?></p>
+    <p><?php __('plain'); ?></p>
     <p><?php __('DATE \a\t TIME'); ?></p>
     <p><?php __("DATE \a\\t TIME"); ?></p>
     <p><?php __("DATE \\a\\t TIME"); ?></p>
     <p><?php __("FIELD\tFIELD"); ?></p>
+    <p><?php __(
+        "text "
+        // test
+        .'concatenated'.
+        /* test*/ " with 'comments'"
+    ); ?></p>
+    <p><?php __($avoid['me']); ?>
+    <p><?php __('Stop at the variable'.$var.'!'); ?>
 </div>

--- a/tests/files/special-chars.php
+++ b/tests/files/special-chars.php
@@ -1,5 +1,5 @@
 <div>
-    <p><?php __('plain'); ?></p>
+    <p><?php __ ( 'plain' ); ?></p>
     <p><?php __('DATE \a\t TIME'); ?></p>
     <p><?php __("DATE \a\\t TIME"); ?></p>
     <p><?php __("DATE \\a\\t TIME"); ?></p>


### PR DESCRIPTION
I run a few tests again a PHP project with ~4300 translatable strings, comparing the results of `xgettext` and those of the `PhpCode` extractor.

I only found two problems:

1) `xgettext` (correctly) does not extracts strings like the `me` in `__($avoid['me'])`. I think that the correct solution would be to do not extract strings with variables (since it does not have any sense), but gettext stops as soon as it find a variable (for instance from `__('Stop at the variable'.$var.'!')` it extracts `Stop at the variable`) - so I'd adopt this same approach for consistency.

2) Consider this example:
```php
__(
  'line1'
 .' line2')
```
xgettext (correctly) extracts `'line1 line2'`, but the `PhpCode` extractor only extracts `'line1'`.

I added some tests here to highlight the above problems.