### PR TITLE
Register np__() along with the other global functions.

### DIFF
--- a/src/BaseTranslator.php
+++ b/src/BaseTranslator.php
@@ -4,12 +4,13 @@ namespace Gettext;
 
 abstract class BaseTranslator implements TranslatorInterface
 {
+    /** @var TranslatorInterface */
     public static $current;
 
     /**
      * Set a translation instance as global, to use it with the gettext functions.
      *
-     * @param Translator $translator
+     * @param TranslatorInterface $translator
      */
     public static function initGettextFunctions(TranslatorInterface $translator)
     {

--- a/src/translator_functions.php
+++ b/src/translator_functions.php
@@ -109,6 +109,29 @@ function dp__($domain, $context, $original)
 }
 
 /**
+ * Returns the singular/plural translation of a string in a specific context.
+ *
+ * @param string $context
+ * @param string $original
+ * @param string $plural
+ * @param string $value
+ *
+ * @return string
+ */
+function np__($context, $original, $plural, $value)
+{
+    $text = BaseTranslator::$current->npgettext($context, $original, $plural, $value);
+
+    if (func_num_args() === 4) {
+        return $text;
+    }
+
+    $args = array_slice(func_get_args(), 4);
+
+    return vsprintf($text, is_array($args[0]) ? $args[0] : $args);
+}
+
+/**
  * Returns the singular/plural translation of a string in a specific domain and context.
  *
  * @param string $domain


### PR DESCRIPTION
This delegates actual translation to `BaseTranslator::$current->npgettext`

I hope this was just an oversight and there isn't a reason to exclude this particular translation function.

Since this is just an alias, I thought testing would not be helpful.