### PR TITLE
Json-Generator: Show all strings with pretty print

### DIFF
--- a/src/Generators/JsonDictionary.php
+++ b/src/Generators/JsonDictionary.php
@@ -3,6 +3,7 @@
 namespace Gettext\Generators;
 
 use Gettext\Translations;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 class JsonDictionary extends Generator implements GeneratorInterface
 {
@@ -18,18 +19,80 @@ class JsonDictionary extends Generator implements GeneratorInterface
 
         // remove meta / header data
         if (array_key_exists('', $values)) {
-            unset($values['']);
+            unset( $values[''] );
         }
 
         //map to a simple json dictionary (no plurals)
-        return json_encode(
+        return static::json_format(
             array_map(
                 function ($val) {
                     return isset( $val[1] ) ? $val[1] : '';
                 },
                 $values
-            ),
-            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE
+            )
         );
+    }
+
+    /*
+     * Pretty print some JSON.
+     *
+     * As taken from http://php.net/manual/en/function.json-encode.php#80339
+     */
+    protected static function json_format($data)
+    {
+        $tab          = "  ";
+        $new_json     = "";
+        $indent_level = 0;
+        $in_string    = false;
+
+        $json = json_encode($data);
+        $len  = strlen($json);
+
+        for ($c = 0; $c < $len; $c++) {
+            $char = $json[$c];
+            switch ($char) {
+                case '{':
+                case '[':
+                    if ( ! $in_string) {
+                        $new_json .= $char."\n".str_repeat($tab, $indent_level + 1);
+                        $indent_level++;
+                    } else {
+                        $new_json .= $char;
+                    }
+                    break;
+                case '}':
+                case ']':
+                    if ( ! $in_string) {
+                        $indent_level--;
+                        $new_json .= "\n".str_repeat($tab, $indent_level).$char;
+                    } else {
+                        $new_json .= $char;
+                    }
+                    break;
+                case ',':
+                    if ( ! $in_string) {
+                        $new_json .= ",\n".str_repeat($tab, $indent_level);
+                    } else {
+                        $new_json .= $char;
+                    }
+                    break;
+                case ':':
+                    if ( ! $in_string) {
+                        $new_json .= ": ";
+                    } else {
+                        $new_json .= $char;
+                    }
+                    break;
+                case '"':
+                    if ($c > 0 && $json[$c - 1] != '\\') {
+                        $in_string = ! $in_string;
+                    }
+                default:
+                    $new_json .= $char;
+                    break;
+            }
+        }
+
+        return $new_json;
     }
 }

--- a/src/Generators/JsonDictionary.php
+++ b/src/Generators/JsonDictionary.php
@@ -23,11 +23,13 @@ class JsonDictionary extends Generator implements GeneratorInterface
 
         //map to a simple json dictionary (no plurals)
         return json_encode(
-            array_filter(
-                array_map(function ($val) {
-                    return isset($val[1]) ? $val[1] : null;
-                }, $values)
-            )
+            array_map(
+                function ($val) {
+                    return isset( $val[1] ) ? $val[1] : '';
+                },
+                $values
+            ),
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE
         );
     }
 }

--- a/tests/JsonDictionaryGeneratorTest.php
+++ b/tests/JsonDictionaryGeneratorTest.php
@@ -18,6 +18,6 @@ class JsonDictionaryGeneratorTest extends PHPUnit_Framework_TestCase
         $translation->setPlural('apples');
         //generate json dict - skips meta, empty translations and plurals
         $json = Gettext\Generators\JsonDictionary::toString($translations);
-        $this->assertEquals('{"text 2":"apple"}', $json);
+        $this->assertEquals(file_get_contents(__DIR__.'/files/generated.json'), $json);
     }
 }

--- a/tests/files/generated.json
+++ b/tests/files/generated.json
@@ -1,0 +1,14 @@
+{
+    "text 1": "",
+    "context\u0004text 1 with context": "",
+    "text 2": "apple",
+    "text 3 (with parenthesis)": "",
+    "text 4 \"with double quotes\"": "",
+    "text 5 'with escaped single quotes'": "",
+    "text 6": "",
+    "text 7 (with parenthesis)": "",
+    "text 8 \"with escaped double quotes\"": "",
+    "text 9 'with single quotes'": "",
+    "text 10 with plural": "",
+    "<div id=\"blog\" class=\"container\">\n    <div class=\"row\">\n        <div class=\"col-md-12\">\n            <div id=\"content\">\n                <div class=\"page_post\">\n                    <div class=\"container\">\n                        <div class=\"margin-top-40\"><\/div>\n                        <div class=\"col-sm-3 col-md-2 centered-xs an-number\">4<\/div>\n                    <\/div>\n                <\/div>\n                <div class=\"container\">\n                    <h1 class=\"text-center margin-top-10\">Sorry, but we couldn't find this page<\/h1>\n                    <div id=\"body-div\">\n                        <div id=\"main-div\">\n                            <div class=\"text-404\">\n                                <div>\n                                    <p>Maybe you have entered an incorrect URL of the page or page moved to another section or just page is temporarily unavailable.<\/p>\n                                <\/div>\n                            <\/div>\n                        <\/div>\n                    <\/div>\n                <\/div>\n            <\/div>\n        <\/div>\n    <\/div>\n<\/div>": ""
+}

--- a/tests/files/generated.json
+++ b/tests/files/generated.json
@@ -1,14 +1,14 @@
 {
-    "text 1": "",
-    "context\u0004text 1 with context": "",
-    "text 2": "apple",
-    "text 3 (with parenthesis)": "",
-    "text 4 \"with double quotes\"": "",
-    "text 5 'with escaped single quotes'": "",
-    "text 6": "",
-    "text 7 (with parenthesis)": "",
-    "text 8 \"with escaped double quotes\"": "",
-    "text 9 'with single quotes'": "",
-    "text 10 with plural": "",
-    "<div id=\"blog\" class=\"container\">\n    <div class=\"row\">\n        <div class=\"col-md-12\">\n            <div id=\"content\">\n                <div class=\"page_post\">\n                    <div class=\"container\">\n                        <div class=\"margin-top-40\"><\/div>\n                        <div class=\"col-sm-3 col-md-2 centered-xs an-number\">4<\/div>\n                    <\/div>\n                <\/div>\n                <div class=\"container\">\n                    <h1 class=\"text-center margin-top-10\">Sorry, but we couldn't find this page<\/h1>\n                    <div id=\"body-div\">\n                        <div id=\"main-div\">\n                            <div class=\"text-404\">\n                                <div>\n                                    <p>Maybe you have entered an incorrect URL of the page or page moved to another section or just page is temporarily unavailable.<\/p>\n                                <\/div>\n                            <\/div>\n                        <\/div>\n                    <\/div>\n                <\/div>\n            <\/div>\n        <\/div>\n    <\/div>\n<\/div>": ""
+  "text 1": "",
+  "context\u0004text 1 with context": "",
+  "text 2": "apple",
+  "text 3 (with parenthesis)": "",
+  "text 4 \"with double quotes\"": "",
+  "text 5 'with escaped single quotes'": "",
+  "text 6": "",
+  "text 7 (with parenthesis)": "",
+  "text 8 \"with escaped double quotes\"": "",
+  "text 9 'with single quotes'": "",
+  "text 10 with plural": "",
+  "<div id=\"blog\" class=\"container\">\n    <div class=\"row\">\n        <div class=\"col-md-12\">\n            <div id=\"content\">\n                <div class=\"page_post\">\n                    <div class=\"container\">\n                        <div class=\"margin-top-40\"><\/div>\n                        <div class=\"col-sm-3 col-md-2 centered-xs an-number\">4<\/div>\n                    <\/div>\n                <\/div>\n                <div class=\"container\">\n                    <h1 class=\"text-center margin-top-10\">Sorry, but we couldn't find this page<\/h1>\n                    <div id=\"body-div\">\n                        <div id=\"main-div\">\n                            <div class=\"text-404\">\n                                <div>\n                                    <p>Maybe you have entered an incorrect URL of the page or page moved to another section or just page is temporarily unavailable.<\/p>\n                                <\/div>\n                            <\/div>\n                        <\/div>\n                    <\/div>\n                <\/div>\n            <\/div>\n        <\/div>\n    <\/div>\n<\/div>": ""
 }


### PR DESCRIPTION
The Json-Generator filtered untranslated string out for the JSON-File.
With such file a developer needs more time to translate things
because he needs to look it up several times.

For a better workflow all translatable strings are included in the JSON-File.
With pretty-print (>= PHP 5.4) the JSON is more human readable.
