### PR TITLE
New feature: Method/function gettext_noop

### DIFF
--- a/src/BaseTranslator.php
+++ b/src/BaseTranslator.php
@@ -10,6 +10,14 @@ abstract class BaseTranslator implements TranslatorInterface
     /**
      * @see TranslatorInterface
      */
+    public function gettext_noop($original)
+    {
+        return $original;
+    }
+
+    /**
+     * @see TranslatorInterface
+     */
     public function register()
     {
         $previous = self::$current;

--- a/src/BaseTranslator.php
+++ b/src/BaseTranslator.php
@@ -10,7 +10,7 @@ abstract class BaseTranslator implements TranslatorInterface
     /**
      * @see TranslatorInterface
      */
-    public function gettext_noop($original)
+    public function noop($original)
     {
         return $original;
     }

--- a/src/Extractors/JsCode.php
+++ b/src/Extractors/JsCode.php
@@ -26,6 +26,7 @@ class JsCode extends Extractor implements ExtractorInterface
             'np__' => 'npgettext',
             'dnpgettext' => 'dnpgettext',
             'dnp__' => 'dnpgettext',
+            'gettext_noop' => 'noop',
         ],
     ];
 

--- a/src/Extractors/PhpCode.php
+++ b/src/Extractors/PhpCode.php
@@ -31,6 +31,7 @@ class PhpCode extends Extractor implements ExtractorInterface
             'np__' => 'npgettext',
             'dnpgettext' => 'dnpgettext',
             'dnp__' => 'dnpgettext',
+            'noop' => 'noop',
         ],
     ];
 

--- a/src/Extractors/PhpCode.php
+++ b/src/Extractors/PhpCode.php
@@ -32,6 +32,7 @@ class PhpCode extends Extractor implements ExtractorInterface
             'dnpgettext' => 'dnpgettext',
             'dnp__' => 'dnpgettext',
             'noop' => 'noop',
+            'noop__' => 'noop',
         ],
     ];
 

--- a/src/TranslatorInterface.php
+++ b/src/TranslatorInterface.php
@@ -22,7 +22,7 @@ interface TranslatorInterface
      *
      * @return string
      */
-    public function gettext_noop($original);
+    public function noop($original);
 
     /**
      * Gets a translation using the original string.

--- a/src/TranslatorInterface.php
+++ b/src/TranslatorInterface.php
@@ -10,10 +10,19 @@ interface TranslatorInterface
     /**
      * Register this translator as global, to use with the gettext functions __(), p__(), etc.
      * Returns the previous translator if exists.
-     * 
+     *
      * @return TranslatorInterface|null
      */
     public function register();
+
+    /**
+     * Noop, marks the string for translation but returns it unchanged.
+     *
+     * @param string $original
+     *
+     * @return string
+     */
+    public function gettext_noop($original);
 
     /**
      * Gets a translation using the original string.

--- a/src/translator_functions.php
+++ b/src/translator_functions.php
@@ -23,6 +23,18 @@ function __($original)
 }
 
 /**
+ * Noop, marks the string for translation but returns it unchanged.
+ *
+ * @param string $original
+ *
+ * @return string
+ */
+function N__($original)
+{
+    return $original;
+}
+
+/**
  * Returns the singular/plural translation of a string.
  *
  * @param string $original
@@ -154,3 +166,4 @@ function dnp__($domain, $context, $original, $plural, $value)
 
     return vsprintf($text, is_array($args[0]) ? $args[0] : $args);
 }
+

--- a/src/translator_functions.php
+++ b/src/translator_functions.php
@@ -29,7 +29,7 @@ function __($original)
  *
  * @return string
  */
-function N__($original)
+function noop($original)
 {
     return $original;
 }

--- a/src/translator_functions.php
+++ b/src/translator_functions.php
@@ -29,7 +29,7 @@ function __($original)
  *
  * @return string
  */
-function noop($original)
+function noop__($original)
 {
     return $original;
 }

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -11,7 +11,7 @@ class TranslatorTest extends AbstractTest
     {
         $t = new Translator();
         $original = 'original string';
-        $this->assertEquals($original, $t->gettext_noop($original));
+        $this->assertEquals($original, $t->noop($original));
     }
 
     public function testOne()

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -7,6 +7,13 @@ use Gettext\Translator;
 
 class TranslatorTest extends AbstractTest
 {
+    public function testNoop()
+    {
+        $t = new Translator();
+        $original = 'original string';
+        $this->assertEquals($original, $t->gettext_noop($original));
+    }
+
     public function testOne()
     {
         $t = new Translator();


### PR DESCRIPTION
While PHP's gettext-library lacks `gettext_noop()`, several other languages (and frameworks) has one (C, C++, and GCC, Lisp, Scheme, perl as per https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/xgettext-Invocation.html). 

`gettext_noop()` marks a string as translatable, in order to make it discoverable by extractors, without actually translating it. It is a workaround for translating the contents of variables: as the variable is set, its contents are also marked with `gettext_noop()`:

```
# earlier in the code, discoverable by parsing extractors...
$message = gettext_noop('This is the message');

# later in the code...
echo gettext($message);
```
While some language-dependent variant of "gettext-noop" seems to be in use everywhere that has it, the actual look (or necessity) of `N__` is up for debate.