### PR TITLE
Adding support for named placeholders in functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ echo __('apple'); // "Mazá"
 The benefits of using the functions provided by this library (`__()` instead `_()` or `gettext()`) are:
 
 * You are using the same functions, no matter whether the translations are provided by gettext extension or any other method
-* You can use variables easier because sprintf functionality is included. For example: `__('Hello %s', 'world')` instead `sprintf(_('Hello %s'), 'world')`.
+* You can use variables easier because `sprintf` functionality is included. For example: `__('Hello %s', 'world')` instead `sprintf(_('Hello %s'), 'world')`.
+* You can also use named placeholders if the second argument is an array. For example: `__('Hello %name%', ['%name' => 'world'])` instead of `strtr(_('Hello %name%'), ['%name%' => 'world'])`
 
 ## Translation
 

--- a/src/translator_functions.php
+++ b/src/translator_functions.php
@@ -19,7 +19,7 @@ function __($original)
 
     $args = array_slice(func_get_args(), 1);
 
-    return vsprintf($text, is_array($args[0]) ? $args[0] : $args);
+    return is_array($args[0]) ? strtr($text, $args[0]) : vsprintf($text, $args);
 }
 
 /**
@@ -53,7 +53,7 @@ function n__($original, $plural, $value)
 
     $args = array_slice(func_get_args(), 3);
 
-    return vsprintf($text, is_array($args[0]) ? $args[0] : $args);
+    return is_array($args[0]) ? strtr($text, $args[0]) : vsprintf($text, $args);
 }
 
 /**
@@ -74,7 +74,7 @@ function p__($context, $original)
 
     $args = array_slice(func_get_args(), 2);
 
-    return vsprintf($text, is_array($args[0]) ? $args[0] : $args);
+    return is_array($args[0]) ? strtr($text, $args[0]) : vsprintf($text, $args);
 }
 
 /**
@@ -95,7 +95,7 @@ function d__($domain, $original)
 
     $args = array_slice(func_get_args(), 2);
 
-    return vsprintf($text, is_array($args[0]) ? $args[0] : $args);
+    return is_array($args[0]) ? strtr($text, $args[0]) : vsprintf($text, $args);
 }
 
 /**
@@ -117,7 +117,7 @@ function dp__($domain, $context, $original)
 
     $args = array_slice(func_get_args(), 3);
 
-    return vsprintf($text, is_array($args[0]) ? $args[0] : $args);
+    return is_array($args[0]) ? strtr($text, $args[0]) : vsprintf($text, $args);
 }
 
 /**
@@ -140,7 +140,7 @@ function np__($context, $original, $plural, $value)
 
     $args = array_slice(func_get_args(), 4);
 
-    return vsprintf($text, is_array($args[0]) ? $args[0] : $args);
+    return is_array($args[0]) ? strtr($text, $args[0]) : vsprintf($text, $args);
 }
 
 /**
@@ -164,5 +164,5 @@ function dnp__($domain, $context, $original, $plural, $value)
 
     $args = array_slice(func_get_args(), 5);
 
-    return vsprintf($text, is_array($args[0]) ? $args[0] : $args);
+    return is_array($args[0]) ? strtr($text, $args[0]) : vsprintf($text, $args);
 }

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -3,6 +3,7 @@
 namespace Gettext\Tests;
 
 use Gettext\Translations;
+use Gettext\Translation;
 use Gettext\Translator;
 
 class TranslatorTest extends AbstractTest
@@ -32,7 +33,7 @@ class TranslatorTest extends AbstractTest
         $this->assertEquals('Value %sr is not a valid choice.', $t->gettext('Value %sr is not a valid choice.'));
     }
 
-    public function testFunctions()
+    public function testOneFunction()
     {
         $t = new Translator();
         $t->loadTranslations(static::get('po2/Po'));
@@ -43,6 +44,10 @@ class TranslatorTest extends AbstractTest
         $this->assertEquals('Ovo polje ne može biti prazno.', __('This field cannot be blank.'));
         $this->assertEquals('Value %sr is not a valid choice.', __('Value %sr is not a valid choice.'));
         $this->assertEquals('Value hellor is not a valid choice.', __('Value %sr is not a valid choice.', 'hello'));
+        $this->assertEquals('Value 0r is not a valid choice.', __('Value %sr is not a valid choice.', 0));
+        $this->assertEquals('Value r is not a valid choice.', __('Value %sr is not a valid choice.', null));
+        $this->assertEquals('1s mora da bude jedinstven za 2s 3s.', __('%ss must be unique for %ss %ss.', '1', '2', '3'));
+        $this->assertEquals('Value hellor is not a valid choice.', __('Value %sr is not a valid choice.', ['%s' => 'hello']));
     }
 
     public function testPlural()
@@ -65,6 +70,136 @@ class TranslatorTest extends AbstractTest
 
         // Test that non-plural translations the fallback still works.
         $this->assertEquals('more', $t->ngettext('single', 'more', 3));
+    }
+
+    public function testPluralFunction()
+    {
+        $translations = new Translations();
+        $translations[] = 
+            (new Translation(null, 'One comment', '%s comments'))
+            ->setTranslation('Un commentaire')
+            ->setPluralTranslations(['%s commentaires']);
+        $t = new Translator();
+        $t->loadTranslations($translations);
+
+        $t->register();
+
+        $this->assertEquals('%s commentaires',          n__('One comment', '%s comments', 3));
+        $this->assertEquals('beaucoup de commentaires', n__('One comment', '%s comments', 3, 'beaucoup de'));
+        $this->assertEquals('0 commentaires', n__('One comment', '%s comments', 3, 0));
+        $this->assertEquals(' commentaires', n__('One comment', '%s comments', 3, null));
+        $this->assertEquals('beaucoup de commentaires', n__('One comment', '%s comments', 3, ['%s' => 'beaucoup de']));
+    }
+
+    public function testContextFunction()
+    {
+        $translations = new Translations();
+        $translations[] = 
+            (new Translation('daytime', 'Hello %s'))
+            ->setTranslation('Bonjour %s');
+        $translations[] = 
+            (new Translation('nightime', 'Hello %s'))
+            ->setTranslation('Bonsoir %s');
+        $t = new Translator();
+        $t->loadTranslations($translations);
+
+        $t->register();
+
+        $this->assertEquals('Bonjour %s', p__('daytime','Hello %s'));
+        $this->assertEquals('Bonjour John', p__('daytime','Hello %s', 'John'));
+        $this->assertEquals('Bonjour 0', p__('daytime','Hello %s', 0));
+        $this->assertEquals('Bonjour ', p__('daytime','Hello %s', null));
+        $this->assertEquals('Bonjour John', p__('daytime','Hello %s',['%s' => 'John']));
+        $this->assertEquals('Bonsoir John', p__('nightime','Hello %s', 'John'));
+        $this->assertEquals('Bonsoir John', p__('nightime','Hello %s',['%s' => 'John']));
+    }
+
+    public function testDomainFunction()
+    {
+        $translations = new Translations();
+        $translations->setDomain('messages');
+        $translations[] = 
+            (new Translation(null, 'Hello %s'))
+            ->setTranslation('Bonjour %s');
+        $t = new Translator();
+        $t->loadTranslations($translations);
+
+        $t->register();
+
+        $this->assertEquals('Bonjour %s',   d__('messages','Hello %s'));
+        $this->assertEquals('Bonjour John', d__('messages','Hello %s','John'));
+        $this->assertEquals('Bonjour 0', d__('messages','Hello %s',0));
+        $this->assertEquals('Bonjour ', d__('messages','Hello %s',null));
+        $this->assertEquals('Bonjour John', d__('messages','Hello %s',['%s' => 'John']));
+        $this->assertEquals('Hello %s',     d__('errors','Hello %s'));
+        $this->assertEquals('Hello John',   d__('errors','Hello %s',['%s' => 'John']));
+    }
+
+    public function testDomainAndContextFunction()
+    {
+        $translations = new Translations();
+        $translations->setDomain('messages');
+        $translations[] = 
+            (new Translation('daytime', 'Hello %s'))
+            ->setTranslation('Bonjour %s');
+        $translations[] = 
+            (new Translation('nightime', 'Hello %s'))
+            ->setTranslation('Bonsoir %s');
+        $t = new Translator();
+        $t->loadTranslations($translations);
+
+        $t->register();
+
+        $this->assertEquals('Bonjour %s',   dp__('messages','daytime','Hello %s'));
+        $this->assertEquals('Bonjour John', dp__('messages','daytime','Hello %s', 'John'));
+        $this->assertEquals('Bonjour 0', dp__('messages','daytime','Hello %s', 0));
+        $this->assertEquals('Bonjour ', dp__('messages','daytime','Hello %s', null));
+        $this->assertEquals('Bonjour John', dp__('messages','daytime','Hello %s',['%s' => 'John']));
+        $this->assertEquals('Bonsoir John', dp__('messages','nightime','Hello %s', 'John'));
+        $this->assertEquals('Bonsoir John', dp__('messages','nightime','Hello %s',['%s' => 'John']));
+        $this->assertEquals('Hello John',   dp__('errors','daytime','Hello %s',['%s' => 'John']));
+    }
+
+    public function testPluralAndContextFunction()
+    {
+        $translations = new Translations();
+        $translations[] = 
+            (new Translation('comment', 'One comment', '%s comments'))
+            ->setTranslation('Un commentaire')
+            ->setPluralTranslations(['%s commentaires']);
+        $t = new Translator();
+        $t->loadTranslations($translations);
+
+        $t->register();
+
+        $this->assertEquals('%s commentaires',          np__('comment', 'One comment', '%s comments', 3));
+        $this->assertEquals('0 commentaires',          np__('comment', 'One comment', '%s comments', 3, 0));
+        $this->assertEquals(' commentaires',          np__('comment', 'One comment', '%s comments', 3, null));
+        $this->assertEquals('beaucoup de commentaires', np__('comment', 'One comment', '%s comments', 3, 'beaucoup de'));
+        $this->assertEquals('beaucoup de commentaires', np__('comment', 'One comment', '%s comments', 3, ['%s' => 'beaucoup de']));
+        $this->assertEquals('3 comments', np__(null, 'One comment', '%s comments', 3, ['%s' => 3]));
+    }
+
+    public function testPluralAndContextAndDomainFunction()
+    {
+        $translations = new Translations();
+        $translations->setDomain('messages');
+        $translations[] = 
+            (new Translation('comment', 'One comment', '%s comments'))
+            ->setTranslation('Un commentaire')
+            ->setPluralTranslations(['%s commentaires']);
+        $t = new Translator();
+        $t->loadTranslations($translations);
+
+        $t->register();
+
+        $this->assertEquals('%s commentaires',          dnp__('messages', 'comment', 'One comment', '%s comments', 3));
+        $this->assertEquals('0 commentaires',          dnp__('messages', 'comment', 'One comment', '%s comments', 3, 0));
+        $this->assertEquals(' commentaires',          dnp__('messages', 'comment', 'One comment', '%s comments', 3, null));
+        $this->assertEquals('beaucoup de commentaires', dnp__('messages', 'comment', 'One comment', '%s comments', 3, 'beaucoup de'));
+        $this->assertEquals('beaucoup de commentaires', dnp__('messages', 'comment', 'One comment', '%s comments', 3, ['%s' => 'beaucoup de']));
+        $this->assertEquals('beaucoup de comments', dnp__('errors', 'comment', 'One comment', '%s comments', 3, ['%s' => 'beaucoup de']));
+        $this->assertEquals('beaucoup de comments', dnp__('messages', null, 'One comment', '%s comments', 3, ['%s' => 'beaucoup de']));
     }
 
     public function testNonLoadedTranslations()


### PR DESCRIPTION
When the last argument is an array, strtr will be used instead of vsprintf for all the functions `__()`, `n__()`, etc.

This allow using named placeholders, e.g.

`__('Hello %name%', ['%name' => 'world'])`

Existing syntax using vsprintf is preserved, e.g.

`__('Hello %s', 'world')`

Fix #138

Notes:

- I explicitly added `$args` to the function declaration to avoid calling `func_num_args()` if not necessary. It is marginally faster.
- I didn't find existing tests for all the `*gettext` methods/functions so I added a bunch.