### PR TITLE
Fixed JavaScript source extraction with single quoted functions

### DIFF
--- a/src/Utils/JsFunctionsScanner.php
+++ b/src/Utils/JsFunctionsScanner.php
@@ -102,6 +102,7 @@ class JsFunctionsScanner extends FunctionsScanner
 
                 case '(':
                     switch ($this->status()) {
+                        case 'simple-quote':
                         case 'double-quote':
                         case 'line-comment':
                         case 'block-comment':


### PR DESCRIPTION
Fixed extracting single quoted messages from JavaScript source codes, as described in issue #140 