### PR TITLE
Make csv options configurable via $options

### DIFF
--- a/src/Extractors/Csv.php
+++ b/src/Extractors/Csv.php
@@ -12,17 +12,24 @@ class Csv extends Extractor implements ExtractorInterface
 {
     use HeadersExtractorTrait;
 
+    public static $options = [
+        'delimiter' => ",",
+        'enclosure' => '"',
+        'escape' => "\\"
+    ];
+
     /**
      * {@inheritdoc}
      */
     public static function fromString($string, Translations $translations, array $options = [])
     {
+        $options += static::$options;
         $handle = fopen('php://memory', 'w');
 
         fputs($handle, $string);
         rewind($handle);
 
-        while ($row = fgetcsv($handle)) {
+        while ($row = fgetcsv($handle, null, $options['delimiter'], $options['enclosure'], $options['escape'])) {
             $context = array_shift($row);
             $original = array_shift($row);
 

--- a/src/Extractors/Csv.php
+++ b/src/Extractors/Csv.php
@@ -15,7 +15,7 @@ class Csv extends Extractor implements ExtractorInterface
     public static $options = [
         'delimiter' => ",",
         'enclosure' => '"',
-        'escape' => "\\"
+        'escape_char' => "\\"
     ];
 
     /**
@@ -29,7 +29,7 @@ class Csv extends Extractor implements ExtractorInterface
         fputs($handle, $string);
         rewind($handle);
 
-        while ($row = fgetcsv($handle, null, $options['delimiter'], $options['enclosure'], $options['escape'])) {
+        while ($row = self::getcsv($handle, $options)) {
             $context = array_shift($row);
             $original = array_shift($row);
 
@@ -47,5 +47,20 @@ class Csv extends Extractor implements ExtractorInterface
         }
 
         fclose($handle);
+    }
+
+    /**
+     * @param resource $handle
+     * @param array $options
+     *
+     * @return array
+     */
+    private static function getcsv($handle, $options)
+    {
+        if (version_compare(PHP_VERSION, '5.3.0') >= 0) { // >= 5.3
+            return fgetcsv($handle, null, $options['delimiter'], $options['enclosure'], $options['escape_char']);
+        }
+
+        return fgetcsv($handle, null, $options['delimiter'], $options['enclosure']);
     }
 }

--- a/src/Generators/Csv.php
+++ b/src/Generators/Csv.php
@@ -28,7 +28,7 @@ class Csv extends Generator implements GeneratorInterface
         $handle = fopen('php://memory', 'w');
 
         if ($options['includeHeaders']) {
-            fputcsv($handle, ['', '', self::generateHeaders($translations)], $options['delimiter'], $options['enclosure'], $options['escape_char']);
+            self::fputcsv($handle, ['', '', self::generateHeaders($translations)], $options);
         }
 
         foreach ($translations as $translation) {
@@ -38,7 +38,7 @@ class Csv extends Generator implements GeneratorInterface
                 $line = array_merge($line, $translation->getPluralTranslations());
             }
 
-            fputcsv($handle, $line, $options['delimiter'], $options['enclosure'], $options['escape_char']);
+            self::fputcsv($handle, $line, $options);
         }
 
         rewind($handle);
@@ -46,5 +46,21 @@ class Csv extends Generator implements GeneratorInterface
         fclose($handle);
 
         return $csv;
+    }
+
+    /**
+     * @param resource $handle
+     * @param array $fields
+     * @param array $options
+     *
+     * @return bool|int
+     */
+    private static function fputcsv($handle, $fields, $options)
+    {
+        if (version_compare(PHP_VERSION, '5.5.4') >= 0) { // >= 5.5.4
+            return fputcsv($handle, $fields, $options['delimiter'], $options['enclosure'], $options['escape_char']);
+        }
+
+        return fputcsv($handle, $fields, $options['delimiter'], $options['enclosure']);
     }
 }

--- a/src/Generators/Csv.php
+++ b/src/Generators/Csv.php
@@ -14,6 +14,9 @@ class Csv extends Generator implements GeneratorInterface
 
     public static $options = [
         'includeHeaders' => false,
+        'delimiter' => ",",
+        'enclosure' => '"',
+        'escape_char' => "\\"
     ];
 
     /**
@@ -25,7 +28,7 @@ class Csv extends Generator implements GeneratorInterface
         $handle = fopen('php://memory', 'w');
 
         if ($options['includeHeaders']) {
-            fputcsv($handle, ['', '', self::generateHeaders($translations)]);
+            fputcsv($handle, ['', '', self::generateHeaders($translations)], $options['delimiter'], $options['enclosure'], $options['escape_char']);
         }
 
         foreach ($translations as $translation) {
@@ -35,7 +38,7 @@ class Csv extends Generator implements GeneratorInterface
                 $line = array_merge($line, $translation->getPluralTranslations());
             }
 
-            fputcsv($handle, $line);
+            fputcsv($handle, $line, $options['delimiter'], $options['enclosure'], $options['escape_char']);
         }
 
         rewind($handle);


### PR DESCRIPTION
Make csv options configurable via $options, defaults are set to the PHP defaults.

`Translations::fromCsvFile($destination, ['delimiter' => ';']);`

```
$translations->toCsvFile(
    $pathinfo['dirname'] . '/' . $pathinfo['filename'] . '.csv',
    [
        'includeHeaders' => true,
        'delimiter' => ';'
    ]
);
```