### PR TITLE
Unify plural behaviours between PHP gettext and Translator

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -131,8 +131,8 @@ class Translator extends BaseTranslator implements TranslatorInterface
      */
     public function dnpgettext($domain, $context, $original, $plural, $value)
     {
-        $key = $this->getPluralIndex($domain, $value);
         $translation = $this->getTranslation($domain, $context, $original);
+        $key = $this->getPluralIndex($domain, $value, $translation === false);
 
         if (isset($translation[$key]) && $translation[$key] !== '') {
             return $translation[$key];
@@ -197,13 +197,14 @@ class Translator extends BaseTranslator implements TranslatorInterface
      *
      * @param string $domain
      * @param string $n
+     * @param bool   $fallback set to true to get fallback plural index
      *
      * @return int
      */
-    protected function getPluralIndex($domain, $n)
+    protected function getPluralIndex($domain, $n, $fallback)
     {
-        //Not loaded domain, use a fallback
-        if (!isset($this->plurals[$domain])) {
+        //Not loaded domain or translation, use a fallback
+        if (!isset($this->plurals[$domain]) || $fallback === true) {
             return $n == 1 ? 0 : 1;
         }
 

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -70,6 +70,12 @@ class TranslatorTest extends AbstractTest
 
         // Test that non-plural translations the fallback still works.
         $this->assertEquals('more', $t->ngettext('single', 'more', 3));
+
+        $t = new Translator();
+        $t->loadTranslations(static::get('po2/Po'));
+
+        // Test that if the translation is unknown, English plural rules are applied
+        $this->assertEquals('more', $t->ngettext('single', 'more', 21));
     }
 
     public function testPluralFunction()


### PR DESCRIPTION
If the translation key is unknown, we use the English plural rules, as it is done in PHP gettext extension

Fixes #148