### PR TITLE
Correctly passing on options when merging Translations objects

### DIFF
--- a/src/Merge.php
+++ b/src/Merge.php
@@ -159,7 +159,7 @@ class Merge
 
         foreach ($from as $entry) {
             if (($existing = $to->find($entry))) {
-                $existing->mergeWith($entry);
+                $existing->mergeWith($entry, $options);
             } elseif ($options & self::ADD) {
                 $to[] = $entry;
             }


### PR DESCRIPTION
Fix for https://github.com/oscarotero/Gettext/issues/147: It was not possible to overwrite translations correctly when using `mergeWith`, as in:

```
$translations->mergeWith($otherTranslations, Merge::ADD | MERGE::HEADERS_ADD | MERGE::HEADERS_OVERRIDE | Merge::TRANSLATION_OVERRIDE);
```

Options were not correctly passed on to `Merge::mergeTranslations()`.