### PR TITLE
Clone translation before merging

### DIFF
--- a/src/Merge.php
+++ b/src/Merge.php
@@ -161,7 +161,7 @@ class Merge
             if (($existing = $to->find($entry))) {
                 $existing->mergeWith($entry, $options);
             } elseif ($options & self::ADD) {
-                $to[] = $entry;
+                $to[] = $entry->getClone();
             }
         }
     }


### PR DESCRIPTION
Clone translation before merging to avoid unintended modification of referenced `Translation` objects.