### PR TITLE
add fix to skip ' with trailing slash

### DIFF
--- a/src/Utils/JsFunctionsScanner.php
+++ b/src/Utils/JsFunctionsScanner.php
@@ -35,6 +35,13 @@ class JsFunctionsScanner extends FunctionsScanner
             $next = isset($this->code[$pos + 1]) ? $this->code[$pos + 1] : null;
 
             switch ($char) {
+                case '\\':
+                    $prev = $char;
+                    $char = $next;
+                    $pos++;
+                    $next = isset($this->code[$pos]) ? $this->code[$pos] : null;
+                    break;
+
                 case "\n":
                     ++$line;
 
@@ -224,12 +231,6 @@ class JsFunctionsScanner extends FunctionsScanner
     protected static function prepareArgument($argument)
     {
         if ($argument && ($argument[0] === '"' || $argument[0] === "'")) {
-            if ($argument[0] === '"') {
-                $argument = str_replace('\\"', '"', $argument);
-            } else {
-                $argument = str_replace("\\'", "'", $argument);
-            }
-
             return substr($argument, 1, -1);
         }
     }


### PR DESCRIPTION
add fix to skip ' with trailing slash in translation for example {i18n.__('You don\'t have any bookmark.')}