### PR TITLE
Add dn__ function to both extractors and functions scanner

### DIFF
--- a/src/Extractors/JsCode.php
+++ b/src/Extractors/JsCode.php
@@ -22,6 +22,8 @@ class JsCode extends Extractor implements ExtractorInterface
             'p__' => 'pgettext',
             'dgettext' => 'dgettext',
             'd__' => 'dgettext',
+            'dngettext' => 'dngettext',
+            'dn__' => 'dngettext',
             'dpgettext' => 'dpgettext',
             'dp__' => 'dpgettext',
             'npgettext' => 'npgettext',

--- a/src/Extractors/PhpCode.php
+++ b/src/Extractors/PhpCode.php
@@ -28,6 +28,8 @@ class PhpCode extends Extractor implements ExtractorInterface
             'p__' => 'pgettext',
             'dgettext' => 'dgettext',
             'd__' => 'dgettext',
+            'dngettext' => 'dngettext',
+            'dn__' => 'dngettext',
             'dpgettext' => 'dpgettext',
             'dp__' => 'dpgettext',
             'npgettext' => 'npgettext',

--- a/src/Utils/FunctionsScanner.php
+++ b/src/Utils/FunctionsScanner.php
@@ -94,6 +94,14 @@ abstract class FunctionsScanner
                     list($domain, $context, $original, $plural) = $args;
                     break;
 
+                case 'dngettext':
+                    if (!isset($args[3])) {
+                        continue 2;
+                    }
+
+                    list($domain, $original, $plural) = $args;
+                    break;
+
                 default:
                     throw new Exception(sprintf('Not valid function %s', $functions[$name]));
             }


### PR DESCRIPTION
While extracting translations I noticed the `dn__` function was not working. 
I added it to the applicable extractors and functions scanner switch case.