### PR TITLE
php injection - validate eval input from plural forms

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -238,7 +238,7 @@ class Translator extends BaseTranslator implements TranslatorInterface
      */
     private static function fixTerseIfs($code, $inner = false)
     {
-        if(preg_match('~[^\s0-9n<>|&=\-+%?:();\$]~', str_replace('return ', '', $code))) {
+        if (preg_match('~[^\s0-9n<>|&=\-+%?:();\$]~', str_replace('return ', '', $code))) {
             throw new \InvalidArgumentException('Invalid Plural form: ' . $code);
         }
         /*

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -238,6 +238,9 @@ class Translator extends BaseTranslator implements TranslatorInterface
      */
     private static function fixTerseIfs($code, $inner = false)
     {
+        if(preg_match('~[^\s0-9n<>|&=\-+%?:();\$]~', str_replace('return ', '', $code))) {
+            throw new \InvalidArgumentException('Invalid Plural form: ' . $code);
+        }
         /*
          * (?P<expression>[^?]+)   Capture everything up to ? as 'expression'
          * \?                      ?

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -110,7 +110,7 @@ class TranslatorTest extends AbstractTest
 
         $t->register();
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->setExpectedException(\InvalidArgumentException::class);
         n__('One comment', '%s comments', 3);
     }
 

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -97,6 +97,23 @@ class TranslatorTest extends AbstractTest
         $this->assertEquals('beaucoup de commentaires', n__('One comment', '%s comments', 3, ['%s' => 'beaucoup de']));
     }
 
+    public function testPluralInjection()
+    {
+        $translations = new Translations();
+        $translations->setPluralForms(2,'fuu_call()');
+        $translations[] =
+            (new Translation(null, 'One comment', '%s comments'))
+            ->setTranslation('Un commentaire')
+            ->setPluralTranslations(['%s commentaires']);
+        $t = new Translator();
+        $t->loadTranslations($translations);
+
+        $t->register();
+
+        $this->expectException(\InvalidArgumentException::class);
+        n__('One comment', '%s comments', 3);
+    }
+
     public function testContextFunction()
     {
         $translations = new Translations();

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -110,7 +110,7 @@ class TranslatorTest extends AbstractTest
 
         $t->register();
 
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->setExpectedException('InvalidArgumentException');
         n__('One comment', '%s comments', 3);
     }
 


### PR DESCRIPTION
There wasn't any input validation on eval'd code in plural forms. Untrusted translation files could create php injection.