### PR TITLE
Translator comments should be case insensitive

### DIFF
--- a/src/Utils/PhpFunctionsScanner.php
+++ b/src/Utils/PhpFunctionsScanner.php
@@ -179,12 +179,12 @@ class PhpFunctionsScanner extends FunctionsScanner
             if ($value !== '') {
                 if (is_array($this->extractComments)) {
                     foreach ($this->extractComments as $string) {
-                        if (strpos($value, $string) === 0) {
+                        if (stripos($value, $string) === 0) {
                             $result = $value;
                             break;
                         }
                     }
-                } elseif ($this->extractComments === '' || strpos($value, $this->extractComments) === 0) {
+                } elseif ($this->extractComments === '' || stripos($value, $this->extractComments) === 0) {
                     $result = $value;
                 }
             }

--- a/tests/assets/phpcode3/Po.po
+++ b/tests/assets/phpcode3/Po.po
@@ -10,7 +10,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 
 #. allowed1 Comment 1
-#. allowed2 Comment 2
+#. Allowed2 Comment 2
 #: ./tests/assets/phpcode3/input.php:3
 msgid "Translation with comments"
 msgstr ""

--- a/tests/assets/phpcode3/Xliff.xlf
+++ b/tests/assets/phpcode3/Xliff.xlf
@@ -15,7 +15,7 @@
       <notes>
         <note category="context"></note>
         <note category="extracted-comment">allowed1 Comment 1</note>
-        <note category="extracted-comment">allowed2 Comment 2</note>
+        <note category="extracted-comment">Allowed2 Comment 2</note>
         <note category="reference">./tests/assets/phpcode3/input.php:3</note>
       </notes>
       <segment>

--- a/tests/assets/phpcode3/input.php
+++ b/tests/assets/phpcode3/input.php
@@ -2,7 +2,7 @@
 
 __(
 /*allowed1 Comment 1 */
-/*allowed2 Comment 2 */
+/*Allowed2 Comment 2 */
 /* Comment 4 */
 /*not-allowed Comment 3 */
 	'Translation with comments'


### PR DESCRIPTION
I've noticed that in the code base I'm working with the translator comments sometimes start with `translators:` and sometimes with `Translators:`. Instead of passing all possible case variations to the functions scanner, I think it's easier if the extraction happens case insensitive.

This differs from the behavior in `xgettext` but I think makes for a better user experience.