### PR TITLE
Extend .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
-/tests/      export-ignore
-/phpunit.xml export-ignore
-.*           export-ignore
+/tests/         export-ignore
+/phpunit.xml    export-ignore
+.*              export-ignore
+CHANGELOG.md    export-ignore
+CONTRIBUTING.md export-ignore
+phpcs.xml       export-ignore
 
 # Set the line ending configuration
 * text=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,6 @@
 /tests/         export-ignore
 /phpunit.xml    export-ignore
 .*              export-ignore
-CHANGELOG.md    export-ignore
-CONTRIBUTING.md export-ignore
 phpcs.xml       export-ignore
 
 # Set the line ending configuration


### PR DESCRIPTION
There's no need for `CHANGELOG.md`, `CONTRIBUTING.md` and `phpcs.xml` to be part of the package when installing the library via Composer.