### PR TITLE
Fixed incorrect function description

### DIFF
--- a/src/translator_functions.php
+++ b/src/translator_functions.php
@@ -121,7 +121,7 @@ function dp__($domain, $context, $original)
 }
 
 /**
- * Returns the translation of a string in a specific domain and context.
+ * Returns the singular/plural translation of a string in a specific domain.
  *
  * @param string $domain
  * @param string $original


### PR DESCRIPTION
The function description for dn__ seems to have been copy/pasted from dp__ and wasn't reflecting it's actual purpose.