### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "twig/twig": "^1.31|^2.0",
         "twig/extensions": "*",
         "symfony/yaml": "~2",
-        "phpunit/phpunit": "^4.8|^5.7",
+        "phpunit/phpunit": "^4.8|^5.7|^6.5",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,4 +4,9 @@
 			<directory>./tests/</directory>
 		</testsuite>
 	</testsuites>
+	<filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -3,9 +3,9 @@
 namespace Gettext\Tests;
 
 use Gettext\Translations;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractTest extends PHPUnit_Framework_TestCase
+abstract class AbstractTest extends TestCase
 {
     protected static $ext = [
         'Blade' => 'php',

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -93,10 +93,12 @@ class TranslatorTest extends AbstractTest
         $this->assertEquals('beaucoup de commentaires', n__('One comment', '%s comments', 3, ['%s' => 'beaucoup de']));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testPluralInjection()
     {
         $translations = new Translations();
-        $this->setExpectedException('InvalidArgumentException');
         $translations->setPluralForms(2, 'fuu_call()');
     }
 
@@ -106,7 +108,8 @@ class TranslatorTest extends AbstractTest
         $languages = Language::getAll();
 
         foreach ($languages as $language) {
-            $translations->setPluralForms(2, $language->formula);
+            $result = $translations->setPluralForms(2, $language->formula);
+            $this->assertInstanceOf(Translations::class, $result);
         }
     }
 

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -109,7 +109,7 @@ class TranslatorTest extends AbstractTest
 
         foreach ($languages as $language) {
             $result = $translations->setPluralForms(2, $language->formula);
-            $this->assertInstanceOf(Translations::class, $result);
+            $this->assertInstanceOf('Gettext\Translations', $result);
         }
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,11 @@ error_reporting(E_ALL);
 
 include_once dirname(__DIR__).'/vendor/autoload.php';
 
-PHPUnit_Framework_Error_Notice::$enabled = true;
+if(class_exists('PHPUnit_Framework_Error_Notice')) {
+    class_alias('PHPUnit_Framework_Error_Notice', 'PHPUnit\Framework\Error\Notice');
+}
+
+PHPUnit\Framework\Error\Notice::$enabled = true;
 
 //Config
 Gettext\Translations::$options['defaultDateHeaders'] = [];


### PR DESCRIPTION
# Changed log

- Set  the higher PHPUnit version for the ```php-7.2```.
- Use the ```expectedException``` annotation to compatible the different PHPUnit version.
- Let ```testPluralFromValidation``` test method have the ```assertInstanceOf``` assertion and avoid the risky test that don't perform any assertions.