### PR TITLE
VueJs extractor. Fix case when max() fails if array is empty.

### DIFF
--- a/src/Extractors/VueJs.php
+++ b/src/Extractors/VueJs.php
@@ -141,6 +141,10 @@ class VueJs extends JsCode implements ExtractorInterface
     {
         $expressionsByLine = self::getVueAttributeExpressions($options['attributePrefixes'], $dom);
 
+        if (empty($expressionsByLine)) {
+            return '';
+        }
+
         $maxLines = max(array_keys($expressionsByLine));
         $fakeJs = '';
 


### PR DESCRIPTION
PHP max() fails if it is called on an empty array. This fixes the case if no translations are scanned in a JS file.