### PR TITLE
Improving byteorder detection on 64 bit environment

### DIFF
--- a/src/Extractors/Mo.php
+++ b/src/Extractors/Mo.php
@@ -11,10 +11,6 @@ use Gettext\Utils\StringReader;
  */
 class Mo extends Extractor implements ExtractorInterface
 {
-    const MAGIC1 = -1794895138;
-    const MAGIC2 = -569244523;
-    const MAGIC3 = 2500072158;
-
     /**
      * {@inheritdoc}
      */
@@ -23,13 +19,17 @@ class Mo extends Extractor implements ExtractorInterface
         $stream = new StringReader($string);
         $magic = self::readInt($stream, 'V');
 
-        if (($magic === self::MAGIC1) || ($magic === self::MAGIC3)) { //to make sure it works for 64-bit platforms
-            $byteOrder = 'V'; //low endian
-        } elseif ($magic === (self::MAGIC2 & 0xFFFFFFFF)) {
-            $byteOrder = 'N'; //big endian
-        } else {
-            throw new Exception('Not MO file');
-        }
+		$magic_little = (int) - 1794895138;
+		$magic_little_64 = (int) 2500072158;
+		$magic_big = ((int) - 569244523) & 0xFFFFFFFF;
+
+		if ($magic_little == $magic || $magic_little_64 == $magic) { //to make sure it works for 64-bit platforms
+			$byteOrder = 'V'; //low endian
+		} else if ($magic_big == $magic) {
+			$byteOrder = 'N'; //big endian
+		} else {
+			throw new Exception('Not MO file');
+		}
 
         self::readInt($stream, $byteOrder);
 

--- a/src/Extractors/Mo.php
+++ b/src/Extractors/Mo.php
@@ -19,17 +19,17 @@ class Mo extends Extractor implements ExtractorInterface
         $stream = new StringReader($string);
         $magic = self::readInt($stream, 'V');
 
-		$magic_little = (int) - 1794895138;
-		$magic_little_64 = (int) 2500072158;
-		$magic_big = ((int) - 569244523) & 0xFFFFFFFF;
+        $magic_little = (int) - 1794895138;
+        $magic_little_64 = (int) 2500072158;
+        $magic_big = ((int) - 569244523) & 0xFFFFFFFF;
 
-		if ($magic_little == $magic || $magic_little_64 == $magic) { //to make sure it works for 64-bit platforms
-			$byteOrder = 'V'; //low endian
-		} else if ($magic_big == $magic) {
-			$byteOrder = 'N'; //big endian
-		} else {
-			throw new Exception('Not MO file');
-		}
+        if ($magic_little == $magic || $magic_little_64 == $magic) { //to make sure it works for 64-bit platforms
+            $byteOrder = 'V'; //low endian
+        } elseif ($magic_big == $magic) {
+            $byteOrder = 'N'; //big endian
+        } else {
+            throw new Exception('Not MO file');
+        }
 
         self::readInt($stream, $byteOrder);
 


### PR DESCRIPTION
I am not sure this is a PHP bug or not, but PHP cast **2500072158** to **float** on my server. 
(PHP Version 7.2.10-0ubuntu0.18.04.1)
This bug resulting in throw 'Not MO file' exception.
I take WordPress's **get_byteorder()** function as reference, fixed this bug.

![windows64](https://user-images.githubusercontent.com/5100919/46287665-d3533c00-c5b5-11e8-92b9-4ff3f42915bf.png)
![linux64](https://user-images.githubusercontent.com/5100919/46287669-d77f5980-c5b5-11e8-8cb0-97229c46a3cb.png)
