### PR TITLE
Update line numbers for new Twig version

### DIFF
--- a/tests/assets/twig/Po.po
+++ b/tests/assets/twig/Po.po
@@ -9,44 +9,44 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 
-#: ./tests/assets/twig/input.php:38
+#: ./tests/assets/twig/input.php:40
 msgid "text 1"
 msgstr ""
 
-#: ./tests/assets/twig/input.php:45
+#: ./tests/assets/twig/input.php:47
 msgid "text 2"
 msgstr ""
 
-#: ./tests/assets/twig/input.php:49
+#: ./tests/assets/twig/input.php:51
 msgid "text 3 (with parenthesis)"
 msgstr ""
 
-#: ./tests/assets/twig/input.php:53
+#: ./tests/assets/twig/input.php:55
 msgid "text 4 \"with double quotes\""
 msgstr ""
 
-#: ./tests/assets/twig/input.php:57
+#: ./tests/assets/twig/input.php:59
 msgid "text 5 'with escaped single quotes'"
 msgstr ""
 
-#: ./tests/assets/twig/input.php:64
+#: ./tests/assets/twig/input.php:66
 msgid "text 6"
 msgstr ""
 
-#: ./tests/assets/twig/input.php:68
+#: ./tests/assets/twig/input.php:70
 msgid "text 7 (with parenthesis)"
 msgstr ""
 
-#: ./tests/assets/twig/input.php:72
+#: ./tests/assets/twig/input.php:74
 msgid "text 8 \"with escaped double quotes\""
 msgstr ""
 
-#: ./tests/assets/twig/input.php:76
+#: ./tests/assets/twig/input.php:78
 msgid "text 9 'with single quotes'"
 msgstr ""
 
 #. notes: This is an actual note for translators.
-#: ./tests/assets/twig/input.php:82
+#: ./tests/assets/twig/input.php:84
 msgid "text 10 with plural"
 msgid_plural "The plural form"
 msgstr[0] ""

--- a/tests/assets/twig/Xliff.xlf
+++ b/tests/assets/twig/Xliff.xlf
@@ -14,7 +14,7 @@
     <unit id="6c69ee7f211c640419d5366cc076ae46">
       <notes>
         <note category="context"></note>
-        <note category="reference">./tests/assets/twig/input.php:38</note>
+        <note category="reference">./tests/assets/twig/input.php:40</note>
       </notes>
       <segment>
         <source>text 1</source>
@@ -24,7 +24,7 @@
     <unit id="bb3438fbabd460ea6dbd27d153e2233b">
       <notes>
         <note category="context"></note>
-        <note category="reference">./tests/assets/twig/input.php:45</note>
+        <note category="reference">./tests/assets/twig/input.php:47</note>
       </notes>
       <segment>
         <source>text 2</source>
@@ -34,7 +34,7 @@
     <unit id="9da0d4dc2681bf32793a3fd1b8610cb6">
       <notes>
         <note category="context"></note>
-        <note category="reference">./tests/assets/twig/input.php:49</note>
+        <note category="reference">./tests/assets/twig/input.php:51</note>
       </notes>
       <segment>
         <source>text 3 (with parenthesis)</source>
@@ -44,7 +44,7 @@
     <unit id="e7a56b0f57aa5adc31713088d33ec0d2">
       <notes>
         <note category="context"></note>
-        <note category="reference">./tests/assets/twig/input.php:53</note>
+        <note category="reference">./tests/assets/twig/input.php:55</note>
       </notes>
       <segment>
         <source>text 4 "with double quotes"</source>
@@ -54,7 +54,7 @@
     <unit id="615cfcfa32b34e8057fcbd1651247439">
       <notes>
         <note category="context"></note>
-        <note category="reference">./tests/assets/twig/input.php:57</note>
+        <note category="reference">./tests/assets/twig/input.php:59</note>
       </notes>
       <segment>
         <source>text 5 'with escaped single quotes'</source>
@@ -64,7 +64,7 @@
     <unit id="3e220f99f0eed5cc73ab9c599cecc219">
       <notes>
         <note category="context"></note>
-        <note category="reference">./tests/assets/twig/input.php:64</note>
+        <note category="reference">./tests/assets/twig/input.php:66</note>
       </notes>
       <segment>
         <source>text 6</source>
@@ -74,7 +74,7 @@
     <unit id="61aa602f3e368d98288056b1d693c431">
       <notes>
         <note category="context"></note>
-        <note category="reference">./tests/assets/twig/input.php:68</note>
+        <note category="reference">./tests/assets/twig/input.php:70</note>
       </notes>
       <segment>
         <source>text 7 (with parenthesis)</source>
@@ -84,7 +84,7 @@
     <unit id="477f9325bba9979e86c2db696323e2ba">
       <notes>
         <note category="context"></note>
-        <note category="reference">./tests/assets/twig/input.php:72</note>
+        <note category="reference">./tests/assets/twig/input.php:74</note>
       </notes>
       <segment>
         <source>text 8 "with escaped double quotes"</source>
@@ -94,7 +94,7 @@
     <unit id="f9890d4b371274cf0d5917759b6ff419">
       <notes>
         <note category="context"></note>
-        <note category="reference">./tests/assets/twig/input.php:76</note>
+        <note category="reference">./tests/assets/twig/input.php:78</note>
       </notes>
       <segment>
         <source>text 9 'with single quotes'</source>
@@ -105,7 +105,7 @@
       <notes>
         <note category="context"></note>
         <note category="extracted-comment">notes: This is an actual note for translators.</note>
-        <note category="reference">./tests/assets/twig/input.php:82</note>
+        <note category="reference">./tests/assets/twig/input.php:84</note>
       </notes>
       <segment>
         <source>text 10 with plural</source>


### PR DESCRIPTION
This changes the line numbers to let the tests pass again.

Related: https://github.com/oscarotero/Gettext/commit/fe5703caf447320dcaee306c9535016e7f8fac65