### PR TITLE
#224 Allow for setting custom ID to avoid translation clobbering

### DIFF
--- a/src/Extractors/Xliff.php
+++ b/src/Extractors/Xliff.php
@@ -11,11 +11,18 @@ use SimpleXMLElement;
  */
 class Xliff extends Extractor implements ExtractorInterface
 {
+
+    public static $options = [
+        'unitid_as_id' => false
+    ];
+
     /**
      * {@inheritdoc}
      */
     public static function fromString($string, Translations $translations, array $options = [])
     {
+        $options += static::$options;
+
         $xml = new SimpleXMLElement($string, null, false);
 
         foreach ($xml->file as $file) {
@@ -37,7 +44,9 @@ class Xliff extends Extractor implements ExtractorInterface
                     if (isset($unit['id'])) {
                         $unitId = (string) $unit['id'];
                         $translation->addComment("XLIFF_UNIT_ID: $unitId");
-                        $translation->setId($unitId);
+                        if ($options['unitid_as_id']) {
+                            $translation->setId($unitId);
+                        }
                     }
                     $translation->setTranslation(array_shift($targets));
                     $translation->setPluralTranslations($targets);

--- a/src/Extractors/Xliff.php
+++ b/src/Extractors/Xliff.php
@@ -35,7 +35,9 @@ class Xliff extends Extractor implements ExtractorInterface
 
                     $translation = new Translation(null, (string) $segment->source);
                     if (isset($unit['id'])) {
-                        $translation->addComment("XLIFF_UNIT_ID: $unit[id]");
+                        $unitId = (string) $unit['id'];
+                        $translation->addComment("XLIFF_UNIT_ID: $unitId");
+                        $translation->setId($unitId);
                     }
                     $translation->setTranslation(array_shift($targets));
                     $translation->setPluralTranslations($targets);

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -7,6 +7,7 @@ namespace Gettext;
  */
 class Translation
 {
+    protected $id;
     protected $context;
     protected $original;
     protected $translation = '';
@@ -70,13 +71,29 @@ class Translation
     }
 
     /**
+     * Sets the id of this translation.
+     * @warning The use of this function to set a custom ID will prevent
+     *  Translations::find from matching this translation.
+     *
+     * @param string $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+
+    /**
      * Returns the id of this translation.
      *
      * @return string
      */
     public function getId()
     {
-        return static::generateId($this->context, $this->original);
+        if ($this->id === null) {
+            return static::generateId($this->context, $this->original);
+        }
+        return $this->id;
     }
 
     /**

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -413,6 +413,7 @@ class Translations extends ArrayObject
      *
      * @param string|Translation $context  The context of the translation or a translation instance
      * @param string             $original The original string
+     * @warning Translations with custom identifiers (e.g. XLIFF unit IDs) cannot be found using this function.
      *
      * @return Translation|false
      */

--- a/tests/AssetsTest.php
+++ b/tests/AssetsTest.php
@@ -548,9 +548,9 @@ class AssetsTest extends AbstractTest
         }
     }
 
-    public function testXliff()
+    public function testXliffUnitIds()
     {
-        $translations = static::get('xliff/Xliff', 'Xliff');
+        $translations = static::get('xliff/Xliff', 'Xliff', ['unitid_as_id' => true]);
         $countTranslations = 3;
         $countTranslated = 3;
         $countHeaders = 9;

--- a/tests/AssetsTest.php
+++ b/tests/AssetsTest.php
@@ -551,22 +551,33 @@ class AssetsTest extends AbstractTest
     public function testXliff()
     {
         $translations = static::get('xliff/Xliff', 'Xliff');
-        $countTranslations = 2;
-        $countTranslated = 2;
+        $countTranslations = 3;
+        $countTranslated = 3;
         $countHeaders = 9;
 
         $this->assertCount($countTranslations, $translations);
         $this->assertCount($countHeaders, $translations->getHeaders());
-        $this->assertEquals(2, $translations->countTranslated());
+        $this->assertEquals($countTranslated, $translations->countTranslated());
 
-        $translation1 = $translations->find(null, 'one file');
-        $this->assertEquals(\Gettext\Generators\Xliff::getUnitID($translation1), 'custom.unit.id');
+        foreach ($translations as $translation) {
+            switch (\Gettext\Generators\Xliff::getUnitID($translation)) {
+                case 'custom.unit.id':
+                    $this->assertEquals($translation->getOriginal(), 'one file');
+                    $this->assertEquals($translation->getTranslation(), '1 plik');
+                    break;
+                case 'second.custom.unit.id':
+                    $this->assertEquals($translation->getOriginal(), 'one');
+                    $this->assertEquals($translation->getTranslation(), '1');
+                    break;
+                case 'duplicate.source.unit.id':
+                    $this->assertEquals($translation->getOriginal(), 'one');
+                    $this->assertEquals($translation->getTranslation(), 'uno');
+                    break;
+                default:
+                    $this->assertFalse(true);
+            }
+        }
 
-        $translation2 = $translations->find(null, 'one');
-        $this->assertEquals(\Gettext\Generators\Xliff::getUnitID($translation2), 'second.custom.unit.id');
-
-        $this->assertContent($translations, 'xliff/Po');
-
-        $this->runTestFormat('xliff/Po', $countTranslations, $countTranslated, $countHeaders);
+        $this->runTestFormat('xliff/Po', $countTranslations-1, $countTranslated-1, $countHeaders);
     }
 }

--- a/tests/AssetsTest.php
+++ b/tests/AssetsTest.php
@@ -578,6 +578,8 @@ class AssetsTest extends AbstractTest
             }
         }
 
+        // Converting from an XLIFF that contains duplicate <source> elements
+        // to a PO file will result in the loss of the duplicates.
         $this->runTestFormat('xliff/Po', $countTranslations-1, $countTranslated-1, $countHeaders);
     }
 }

--- a/tests/assets/xliff/Xliff.xlf
+++ b/tests/assets/xliff/Xliff.xlf
@@ -31,5 +31,14 @@
         <target>1</target>
       </segment>
     </unit>
+    <unit id="duplicate.source.unit.id">
+      <notes>
+        <note category="context"></note>
+      </notes>
+      <segment>
+        <source>one</source>
+        <target>uno</target>
+      </segment>
+    </unit>
   </file>
 </xliff>


### PR DESCRIPTION
Adds a `Translation::setId` function, with support for the Xliff extractor to call it with the Unit ID.

This permits the library to better conform to xliff's uniqueness requirements (the same source text can be translated several times with different unit IDs) while still supporting PO's uniqueness requirements (the same source text cannot appear twice in the same context).

Note that this means XLIFF files converted to PO files may lose some translations that appear several times with the same source text. (This is necessary to avoid a regression of https://github.com/oscarotero/Gettext/issues/48.)

Note that I did not modify e.g. the PO extractor to use `setId`, even though it supports round-tripping XLIFF unit IDs. These unit IDs can still be read out from the comments or using `\Gettext\Genreators\Xliff::getUnitID`. (This felt like the best design choice.)

Note the warnings in `Translation::setId` and `Translations::find`: Translations with custom IDs (e.g. XLIFF unit IDs) may not be found by the `Translations::find` function, as it searches using IDs generated by the `Translation::generateId` function.

@oscarotero, this may break `Translation::find` for  XLIFF files that were previously generated by this library, as they will use a `md5` sum for the unit ID.