### PR TITLE
Fix for PHP 7.4

### DIFF
--- a/src/Extractors/PhpCode.php
+++ b/src/Extractors/PhpCode.php
@@ -122,11 +122,11 @@ class PhpCode extends Extractor implements ExtractorInterface, ExtractorMultiInt
                     case '\\':
                         return '\\';
                     case 'x':
-                        return chr(hexdec(substr($match[0], 1)));
+                        return chr(hexdec(substr($match[1], 1)));
                     case 'u':
-                        return self::unicodeChar(hexdec(substr($match[0], 1)));
+                        return self::unicodeChar(hexdec(substr($match[1], 1)));
                     default:
-                        return chr(octdec($match[0]));
+                        return chr(octdec($match[1]));
                 }
             },
             $value

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -435,11 +435,13 @@ class Translations extends ArrayObject
      */
     public function countTranslated()
     {
-        $callback = function (Translation $v) {
-            return ($v->hasTranslation()) ? $v->getTranslation() : null;
-        };
-
-        return count(array_filter(get_object_vars($this), $callback));
+        $c = 0;
+		foreach($this as $v) {
+            if ($v->hasTranslation()) {
+                $c++;
+            }
+        }
+        return $c;
     }
 
     /**

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -436,7 +436,7 @@ class Translations extends ArrayObject
     public function countTranslated()
     {
         $c = 0;
-		foreach($this as $v) {
+        foreach ($this as $v) {
             if ($v->hasTranslation()) {
                 $c++;
             }


### PR DESCRIPTION
With this patch:

```
$ vendor/phpunit/phpunit/phpunit 
PHPUnit 5.7.23 by Sebastian Bergmann and contributors.

..........E...................................................... 65 / 99 ( 65%)
..................................                                99 / 99 (100%)

Time: 95 ms, Memory: 8,00MB

There was 1 error:

1) Gettext\Tests\AssetsTest::testTwig
Twig_Error_Syntax: An exception has been thrown during the compilation of a template ("Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`").

/work/GIT/Gettext/vendor/twig/twig/lib/Twig/Environment.php:566
/work/GIT/Gettext/src/Extractors/Twig.php:30
/work/GIT/Gettext/src/Extractors/Extractor.php:18
/work/GIT/Gettext/src/Translations.php:174
/work/GIT/Gettext/src/Translations.php:153
/work/GIT/Gettext/tests/AbstractTest.php:49
/work/GIT/Gettext/tests/AssetsTest.php:384

Caused by
PHPUnit_Framework_Error_Deprecated: Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`

/work/GIT/Gettext/vendor/twig/twig/lib/Twig/Node.php:42
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/Parser.php:349
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/TokenParserInterface.php:42
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/TokenParser.php:17
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/TokenParser/For.php:24
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/Extension/Core.php:116
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/ExtensionSet.php:454
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/ExtensionSet.php:429
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/ExtensionSet.php:398
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/Environment.php:936
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/Lexer.php:353
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/Lexer.php:65
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/Environment.php:505
/work/GIT/Gettext/vendor/twig/twig/lib/Twig/Environment.php:561
/work/GIT/Gettext/src/Extractors/Twig.php:30
/work/GIT/Gettext/src/Extractors/Extractor.php:18
/work/GIT/Gettext/src/Translations.php:174
/work/GIT/Gettext/src/Translations.php:153
/work/GIT/Gettext/tests/AbstractTest.php:49
/work/GIT/Gettext/tests/AssetsTest.php:384

ERRORS!
Tests: 99, Assertions: 1142, Errors: 1.

```

The 2 failures are not related to this project, but to twig