### PR TITLE
Support late static binding across all classes

### DIFF
--- a/src/BaseTranslator.php
+++ b/src/BaseTranslator.php
@@ -20,9 +20,9 @@ abstract class BaseTranslator implements TranslatorInterface
      */
     public function register()
     {
-        $previous = self::$current;
+        $previous = static::$current;
 
-        self::$current = $this;
+        static::$current = $this;
 
         static::includeFunctions();
 

--- a/src/Extractors/Csv.php
+++ b/src/Extractors/Csv.php
@@ -31,12 +31,12 @@ class Csv extends Extractor implements ExtractorInterface
         fputs($handle, $string);
         rewind($handle);
 
-        while ($row = self::fgetcsv($handle, $options)) {
+        while ($row = static::fgetcsv($handle, $options)) {
             $context = array_shift($row);
             $original = array_shift($row);
 
             if ($context === '' && $original === '') {
-                self::extractHeaders(array_shift($row), $translations);
+                static::extractHeaders(array_shift($row), $translations);
                 continue;
             }
 

--- a/src/Extractors/CsvDictionary.php
+++ b/src/Extractors/CsvDictionary.php
@@ -31,11 +31,11 @@ class CsvDictionary extends Extractor implements ExtractorInterface
         fputs($handle, $string);
         rewind($handle);
 
-        while ($row = self::fgetcsv($handle, $options)) {
+        while ($row = static::fgetcsv($handle, $options)) {
             list($original, $translation) = $row + ['', ''];
 
             if ($original === '') {
-                self::extractHeaders($translation, $translations);
+                static::extractHeaders($translation, $translations);
                 continue;
             }
 

--- a/src/Extractors/Extractor.php
+++ b/src/Extractors/Extractor.php
@@ -13,9 +13,9 @@ abstract class Extractor implements ExtractorInterface
      */
     public static function fromFile($file, Translations $translations, array $options = [])
     {
-        foreach (self::getFiles($file) as $file) {
+        foreach (static::getFiles($file) as $file) {
             $options['file'] = $file;
-            static::fromString(self::readFile($file), $translations, $options);
+            static::fromString(static::readFile($file), $translations, $options);
         }
     }
 
@@ -48,7 +48,7 @@ abstract class Extractor implements ExtractorInterface
             $files = [];
 
             foreach ($file as $f) {
-                $files = array_merge($files, self::getFiles($f));
+                $files = array_merge($files, static::getFiles($f));
             }
 
             return $files;

--- a/src/Extractors/Jed.php
+++ b/src/Extractors/Jed.php
@@ -14,7 +14,7 @@ class Jed extends Extractor implements ExtractorInterface
      */
     public static function fromString($string, Translations $translations, array $options = [])
     {
-        self::extract(json_decode($string, true), $translations);
+        static::extract(json_decode($string, true), $translations);
     }
 
     /**

--- a/src/Extractors/JsCode.php
+++ b/src/Extractors/JsCode.php
@@ -42,7 +42,7 @@ class JsCode extends Extractor implements ExtractorInterface, ExtractorMultiInte
      */
     public static function fromString($string, Translations $translations, array $options = [])
     {
-        self::fromStringMultiple($string, [$translations], $options);
+        static::fromStringMultiple($string, [$translations], $options);
     }
 
     /**
@@ -63,9 +63,9 @@ class JsCode extends Extractor implements ExtractorInterface, ExtractorMultiInte
      */
     public static function fromFileMultiple($file, array $translations, array $options = [])
     {
-        foreach (self::getFiles($file) as $file) {
+        foreach (static::getFiles($file) as $file) {
             $options['file'] = $file;
-            static::fromStringMultiple(self::readFile($file), $translations, $options);
+            static::fromStringMultiple(static::readFile($file), $translations, $options);
         }
     }
 }

--- a/src/Extractors/Json.php
+++ b/src/Extractors/Json.php
@@ -20,7 +20,7 @@ class Json extends Extractor implements ExtractorInterface
         $messages = json_decode($string, true);
 
         if (is_array($messages)) {
-            self::fromArray($messages, $translations);
+            static::fromArray($messages, $translations);
         }
     }
 }

--- a/src/Extractors/JsonDictionary.php
+++ b/src/Extractors/JsonDictionary.php
@@ -20,7 +20,7 @@ class JsonDictionary extends Extractor implements ExtractorInterface
         $messages = json_decode($string, true);
 
         if (is_array($messages)) {
-            self::fromArray($messages, $translations);
+            static::fromArray($messages, $translations);
         }
     }
 }

--- a/src/Extractors/Mo.php
+++ b/src/Extractors/Mo.php
@@ -21,27 +21,27 @@ class Mo extends Extractor implements ExtractorInterface
     public static function fromString($string, Translations $translations, array $options = [])
     {
         $stream = new StringReader($string);
-        $magic = self::readInt($stream, 'V');
+        $magic = static::readInt($stream, 'V');
 
-        if (($magic === self::MAGIC1) || ($magic === self::MAGIC3)) { //to make sure it works for 64-bit platforms
+        if (($magic === static::MAGIC1) || ($magic === static::MAGIC3)) { //to make sure it works for 64-bit platforms
             $byteOrder = 'V'; //low endian
-        } elseif ($magic === (self::MAGIC2 & 0xFFFFFFFF)) {
+        } elseif ($magic === (static::MAGIC2 & 0xFFFFFFFF)) {
             $byteOrder = 'N'; //big endian
         } else {
             throw new Exception('Not MO file');
         }
 
-        self::readInt($stream, $byteOrder);
+        static::readInt($stream, $byteOrder);
 
-        $total = self::readInt($stream, $byteOrder); //total string count
-        $originals = self::readInt($stream, $byteOrder); //offset of original table
-        $tran = self::readInt($stream, $byteOrder); //offset of translation table
+        $total = static::readInt($stream, $byteOrder); //total string count
+        $originals = static::readInt($stream, $byteOrder); //offset of original table
+        $tran = static::readInt($stream, $byteOrder); //offset of translation table
 
         $stream->seekto($originals);
-        $table_originals = self::readIntArray($stream, $byteOrder, $total * 2);
+        $table_originals = static::readIntArray($stream, $byteOrder, $total * 2);
 
         $stream->seekto($tran);
-        $table_translations = self::readIntArray($stream, $byteOrder, $total * 2);
+        $table_translations = static::readIntArray($stream, $byteOrder, $total * 2);
 
         for ($i = 0; $i < $total; ++$i) {
             $next = $i * 2;
@@ -105,7 +105,7 @@ class Mo extends Extractor implements ExtractorInterface
      * @param StringReader $stream
      * @param string       $byteOrder
      */
-    private static function readInt(StringReader $stream, $byteOrder)
+    protected static function readInt(StringReader $stream, $byteOrder)
     {
         if (($read = $stream->read(4)) === false) {
             return false;
@@ -121,7 +121,7 @@ class Mo extends Extractor implements ExtractorInterface
      * @param string       $byteOrder
      * @param int          $count
      */
-    private static function readIntArray(StringReader $stream, $byteOrder, $count)
+    protected static function readIntArray(StringReader $stream, $byteOrder, $count)
     {
         return unpack($byteOrder.$count, $stream->read(4 * $count));
     }

--- a/src/Extractors/PhpArray.php
+++ b/src/Extractors/PhpArray.php
@@ -19,7 +19,7 @@ class PhpArray extends Extractor implements ExtractorInterface
     public static function fromFile($file, Translations $translations, array $options = [])
     {
         foreach (static::getFiles($file) as $file) {
-            self::fromArray(include($file), $translations);
+            static::fromArray(include($file), $translations);
         }
     }
 

--- a/src/Extractors/PhpCode.php
+++ b/src/Extractors/PhpCode.php
@@ -48,7 +48,7 @@ class PhpCode extends Extractor implements ExtractorInterface, ExtractorMultiInt
      */
     public static function fromString($string, Translations $translations, array $options = [])
     {
-        self::fromStringMultiple($string, [$translations], $options);
+        static::fromStringMultiple($string, [$translations], $options);
     }
 
     /**
@@ -73,9 +73,9 @@ class PhpCode extends Extractor implements ExtractorInterface, ExtractorMultiInt
      */
     public static function fromFileMultiple($file, array $translations, array $options = [])
     {
-        foreach (self::getFiles($file) as $file) {
+        foreach (static::getFiles($file) as $file) {
             $options['file'] = $file;
-            static::fromStringMultiple(self::readFile($file), $translations, $options);
+            static::fromStringMultiple(static::readFile($file), $translations, $options);
         }
     }
 
@@ -124,7 +124,7 @@ class PhpCode extends Extractor implements ExtractorInterface, ExtractorMultiInt
                     case 'x':
                         return chr(hexdec(substr($match[1], 1)));
                     case 'u':
-                        return self::unicodeChar(hexdec(substr($match[1], 1)));
+                        return static::unicodeChar(hexdec(substr($match[1], 1)));
                     default:
                         return chr(octdec($match[1]));
                 }
@@ -138,7 +138,7 @@ class PhpCode extends Extractor implements ExtractorInterface, ExtractorMultiInt
      * @return string|null
      * @see http://php.net/manual/en/function.chr.php#118804
      */
-    private static function unicodeChar($dec)
+    protected static function unicodeChar($dec)
     {
         if ($dec < 0x80) {
             return chr($dec);

--- a/src/Extractors/Po.php
+++ b/src/Extractors/Po.php
@@ -27,11 +27,11 @@ class Po extends Extractor implements ExtractorInterface
 
         for ($n = count($lines); $i < $n; ++$i) {
             $line = trim($lines[$i]);
-            $line = self::fixMultiLines($line, $lines, $i);
+            $line = static::fixMultiLines($line, $lines, $i);
 
             if ($line === '') {
                 if ($translation->is('', '')) {
-                    self::extractHeaders($translation->getTranslation(), $translations);
+                    static::extractHeaders($translation->getTranslation(), $translations);
                 } elseif ($translation->hasOriginal()) {
                     $translations[] = $translation;
                 }
@@ -80,35 +80,35 @@ class Po extends Extractor implements ExtractorInterface
                     break;
 
                 case 'msgctxt':
-                    $translation = $translation->getClone(self::convertString($data));
+                    $translation = $translation->getClone(static::convertString($data));
                     $append = 'Context';
                     break;
 
                 case 'msgid':
-                    $translation = $translation->getClone(null, self::convertString($data));
+                    $translation = $translation->getClone(null, static::convertString($data));
                     $append = 'Original';
                     break;
 
                 case 'msgid_plural':
-                    $translation->setPlural(self::convertString($data));
+                    $translation->setPlural(static::convertString($data));
                     $append = 'Plural';
                     break;
 
                 case 'msgstr':
                 case 'msgstr[0]':
-                    $translation->setTranslation(self::convertString($data));
+                    $translation->setTranslation(static::convertString($data));
                     $append = 'Translation';
                     break;
 
                 case 'msgstr[1]':
-                    $translation->setPluralTranslations([self::convertString($data)]);
+                    $translation->setPluralTranslations([static::convertString($data)]);
                     $append = 'PluralTranslation';
                     break;
 
                 default:
                     if (strpos($key, 'msgstr[') === 0) {
                         $p = $translation->getPluralTranslations();
-                        $p[] = self::convertString($data);
+                        $p[] = static::convertString($data);
 
                         $translation->setPluralTranslations($p);
                         $append = 'PluralTranslation';
@@ -119,27 +119,27 @@ class Po extends Extractor implements ExtractorInterface
                         if ($append === 'Context') {
                             $translation = $translation->getClone($translation->getContext()
                                 ."\n"
-                                .self::convertString($data));
+                                .static::convertString($data));
                             break;
                         }
 
                         if ($append === 'Original') {
                             $translation = $translation->getClone(null, $translation->getOriginal()
                                 ."\n"
-                                .self::convertString($data));
+                                .static::convertString($data));
                             break;
                         }
 
                         if ($append === 'PluralTranslation') {
                             $p = $translation->getPluralTranslations();
-                            $p[] = array_pop($p)."\n".self::convertString($data);
+                            $p[] = array_pop($p)."\n".static::convertString($data);
                             $translation->setPluralTranslations($p);
                             break;
                         }
 
                         $getMethod = 'get'.$append;
                         $setMethod = 'set'.$append;
-                        $translation->$setMethod($translation->$getMethod()."\n".self::convertString($data));
+                        $translation->$setMethod($translation->$getMethod()."\n".static::convertString($data));
                     }
                     break;
             }
@@ -159,7 +159,7 @@ class Po extends Extractor implements ExtractorInterface
      *
      * @return string
      */
-    private static function fixMultiLines($line, array $lines, &$i)
+    protected static function fixMultiLines($line, array $lines, &$i)
     {
         for ($j = $i, $t = count($lines); $j < $t; ++$j) {
             if (substr($line, -1, 1) == '"'

--- a/src/Extractors/Twig.php
+++ b/src/Extractors/Twig.php
@@ -25,7 +25,7 @@ class Twig extends Extractor implements ExtractorInterface
     {
         $options += static::$options;
 
-        $twig = $options['twig'] ?: self::createTwig();
+        $twig = $options['twig'] ?: static::createTwig();
 
         PhpCode::fromString($twig->compileSource(new Twig_Source($string, '')), $translations, $options);
     }
@@ -35,7 +35,7 @@ class Twig extends Extractor implements ExtractorInterface
      *
      * @return Twig_Environment
      */
-    private static function createTwig()
+    protected static function createTwig()
     {
         $twig = new Twig_Environment(new Twig_Loader_Array(['' => '']));
         $twig->addExtension(new Twig_Extensions_Extension_I18n());

--- a/src/Extractors/Yaml.php
+++ b/src/Extractors/Yaml.php
@@ -21,7 +21,7 @@ class Yaml extends Extractor implements ExtractorInterface
         $messages = YamlParser::parse($string);
 
         if (is_array($messages)) {
-            self::fromArray($messages, $translations);
+            static::fromArray($messages, $translations);
         }
     }
 }

--- a/src/Extractors/YamlDictionary.php
+++ b/src/Extractors/YamlDictionary.php
@@ -21,7 +21,7 @@ class YamlDictionary extends Extractor implements ExtractorInterface
         $messages = YamlParser::parse($string);
 
         if (is_array($messages)) {
-            self::fromArray($messages, $translations);
+            static::fromArray($messages, $translations);
         }
     }
 }

--- a/src/Generators/Csv.php
+++ b/src/Generators/Csv.php
@@ -30,7 +30,7 @@ class Csv extends Generator implements GeneratorInterface
         $handle = fopen('php://memory', 'w');
 
         if ($options['includeHeaders']) {
-            self::fputcsv($handle, ['', '', self::generateHeaders($translations)], $options);
+            static::fputcsv($handle, ['', '', static::generateHeaders($translations)], $options);
         }
 
         foreach ($translations as $translation) {
@@ -44,7 +44,7 @@ class Csv extends Generator implements GeneratorInterface
                 $line = array_merge($line, $translation->getPluralTranslations());
             }
 
-            self::fputcsv($handle, $line, $options);
+            static::fputcsv($handle, $line, $options);
         }
 
         rewind($handle);

--- a/src/Generators/CsvDictionary.php
+++ b/src/Generators/CsvDictionary.php
@@ -26,8 +26,8 @@ class CsvDictionary extends Generator implements GeneratorInterface
         $options += static::$options;
         $handle = fopen('php://memory', 'w');
 
-        foreach (self::toArray($translations, $options['includeHeaders']) as $original => $translation) {
-            self::fputcsv($handle, [$original, $translation], $options);
+        foreach (static::toArray($translations, $options['includeHeaders']) as $original => $translation) {
+            static::fputcsv($handle, [$original, $translation], $options);
         }
 
         rewind($handle);

--- a/src/Generators/Jed.php
+++ b/src/Generators/Jed.php
@@ -25,7 +25,7 @@ class Jed extends Generator implements GeneratorInterface
                     'lang' => $translations->getLanguage() ?: 'en',
                     'plural-forms' => $translations->getHeader('Plural-Forms') ?: 'nplurals=2; plural=(n != 1);',
                 ],
-            ] + self::buildMessages($translations),
+            ] + static::buildMessages($translations),
         ], $options['json']);
     }
 
@@ -36,7 +36,7 @@ class Jed extends Generator implements GeneratorInterface
      *
      * @return array
      */
-    private static function buildMessages(Translations $translations)
+    protected static function buildMessages(Translations $translations)
     {
         $pluralForm = $translations->getPluralForms();
         $pluralSize = is_array($pluralForm) ? ($pluralForm[0] - 1) : null;
@@ -47,7 +47,7 @@ class Jed extends Generator implements GeneratorInterface
             if ($translation->isDisabled()) {
                 continue;
             }
-            
+
             $key = ($translation->hasContext() ? $translation->getContext().$context_glue : '')
                 .$translation->getOriginal();
 

--- a/src/Generators/Json.php
+++ b/src/Generators/Json.php
@@ -21,6 +21,6 @@ class Json extends Generator implements GeneratorInterface
     {
         $options += static::$options;
 
-        return json_encode(self::toArray($translations, $options['includeHeaders'], true), $options['json']);
+        return json_encode(static::toArray($translations, $options['includeHeaders'], true), $options['json']);
     }
 }

--- a/src/Generators/JsonDictionary.php
+++ b/src/Generators/JsonDictionary.php
@@ -21,6 +21,6 @@ class JsonDictionary extends Generator implements GeneratorInterface
     {
         $options += static::$options;
 
-        return json_encode(self::toArray($translations, $options['includeHeaders']), $options['json']);
+        return json_encode(static::toArray($translations, $options['includeHeaders']), $options['json']);
     }
 }

--- a/src/Generators/Mo.php
+++ b/src/Generators/Mo.php
@@ -22,7 +22,7 @@ class Mo extends Generator implements GeneratorInterface
         $messages = [];
 
         if ($options['includeHeaders']) {
-            $messages[''] = self::generateHeaders($translations);
+            $messages[''] = static::generateHeaders($translations);
         }
 
         foreach ($translations as $translation) {

--- a/src/Generators/PhpArray.php
+++ b/src/Generators/PhpArray.php
@@ -18,7 +18,7 @@ class PhpArray extends Generator implements GeneratorInterface
      */
     public static function toString(Translations $translations, array $options = [])
     {
-        $array = self::generate($translations, $options);
+        $array = static::generate($translations, $options);
 
         return '<?php return '.var_export($array, true).';';
     }
@@ -35,6 +35,6 @@ class PhpArray extends Generator implements GeneratorInterface
     {
         $options += static::$options;
 
-        return self::toArray($translations, $options['includeHeaders'], true);
+        return static::toArray($translations, $options['includeHeaders'], true);
     }
 }

--- a/src/Generators/Po.php
+++ b/src/Generators/Po.php
@@ -54,20 +54,20 @@ class Po extends Generator implements GeneratorInterface
             $prefix = $translation->isDisabled() ? '#~ ' : '';
 
             if ($translation->hasContext()) {
-                $lines[] = $prefix.'msgctxt '.self::convertString($translation->getContext());
+                $lines[] = $prefix.'msgctxt '.static::convertString($translation->getContext());
             }
 
-            self::addLines($lines, $prefix.'msgid', $translation->getOriginal());
+            static::addLines($lines, $prefix.'msgid', $translation->getOriginal());
 
             if ($translation->hasPlural()) {
-                self::addLines($lines, $prefix.'msgid_plural', $translation->getPlural());
-                self::addLines($lines, $prefix.'msgstr[0]', $translation->getTranslation());
+                static::addLines($lines, $prefix.'msgid_plural', $translation->getPlural());
+                static::addLines($lines, $prefix.'msgstr[0]', $translation->getTranslation());
 
                 foreach ($translation->getPluralTranslations($pluralSize) as $k => $v) {
-                    self::addLines($lines, $prefix.'msgstr['.($k + 1).']', $v);
+                    static::addLines($lines, $prefix.'msgstr['.($k + 1).']', $v);
                 }
             } else {
-                self::addLines($lines, $prefix.'msgstr', $translation->getTranslation());
+                static::addLines($lines, $prefix.'msgstr', $translation->getTranslation());
             }
 
             $lines[] = '';
@@ -83,16 +83,16 @@ class Po extends Generator implements GeneratorInterface
      *
      * @return string
      */
-    private static function multilineQuote($string)
+    protected static function multilineQuote($string)
     {
         $lines = explode("\n", $string);
         $last = count($lines) - 1;
 
         foreach ($lines as $k => $line) {
             if ($k === $last) {
-                $lines[$k] = self::convertString($line);
+                $lines[$k] = static::convertString($line);
             } else {
-                $lines[$k] = self::convertString($line."\n");
+                $lines[$k] = static::convertString($line."\n");
             }
         }
 
@@ -106,9 +106,9 @@ class Po extends Generator implements GeneratorInterface
      * @param string $name
      * @param string $value
      */
-    private static function addLines(array &$lines, $name, $value)
+    protected static function addLines(array &$lines, $name, $value)
     {
-        $newLines = self::multilineQuote($value);
+        $newLines = static::multilineQuote($value);
 
         if (count($newLines) === 1) {
             $lines[] = $name.' '.$newLines[0];

--- a/src/Generators/Xliff.php
+++ b/src/Generators/Xliff.php
@@ -29,7 +29,7 @@ class Xliff extends Generator implements GeneratorInterface
         $notes = $dom->createElement('notes');
 
         foreach ($translations->getHeaders() as $name => $value) {
-            $notes->appendChild(self::createTextNode($dom, 'note', $value))->setAttribute('id', $name);
+            $notes->appendChild(static::createTextNode($dom, 'note', $value))->setAttribute('id', $name);
         }
 
         if ($notes->hasChildNodes()) {
@@ -38,7 +38,7 @@ class Xliff extends Generator implements GeneratorInterface
 
         foreach ($translations as $translation) {
             //Find an XLIFF unit ID, if one is available; otherwise generate
-            $unitId = self::getUnitID($translation)?:md5($translation->getContext().$translation->getOriginal());
+            $unitId = static::getUnitID($translation)?:md5($translation->getContext().$translation->getOriginal());
 
             $unit = $dom->createElement('unit');
             $unit->setAttribute('id', $unitId);
@@ -46,43 +46,43 @@ class Xliff extends Generator implements GeneratorInterface
             //Save comments as notes
             $notes = $dom->createElement('notes');
 
-            $notes->appendChild(self::createTextNode($dom, 'note', $translation->getContext()))
+            $notes->appendChild(static::createTextNode($dom, 'note', $translation->getContext()))
                 ->setAttribute('category', 'context');
 
             foreach ($translation->getComments() as $comment) {
                 //Skip XLIFF unit ID comments.
-                if (preg_match(self::UNIT_ID_REGEXP, $comment)) {
+                if (preg_match(static::UNIT_ID_REGEXP, $comment)) {
                     continue;
                 }
 
-                $notes->appendChild(self::createTextNode($dom, 'note', $comment))
+                $notes->appendChild(static::createTextNode($dom, 'note', $comment))
                     ->setAttribute('category', 'comment');
             }
 
             foreach ($translation->getExtractedComments() as $comment) {
-                $notes->appendChild(self::createTextNode($dom, 'note', $comment))
+                $notes->appendChild(static::createTextNode($dom, 'note', $comment))
                     ->setAttribute('category', 'extracted-comment');
             }
 
             foreach ($translation->getFlags() as $flag) {
-                $notes->appendChild(self::createTextNode($dom, 'note', $flag))
+                $notes->appendChild(static::createTextNode($dom, 'note', $flag))
                     ->setAttribute('category', 'flag');
             }
 
             foreach ($translation->getReferences() as $reference) {
-                $notes->appendChild(self::createTextNode($dom, 'note', $reference[0].':'.$reference[1]))
+                $notes->appendChild(static::createTextNode($dom, 'note', $reference[0].':'.$reference[1]))
                     ->setAttribute('category', 'reference');
             }
 
             $unit->appendChild($notes);
 
             $segment = $unit->appendChild($dom->createElement('segment'));
-            $segment->appendChild(self::createTextNode($dom, 'source', $translation->getOriginal()));
-            $segment->appendChild(self::createTextNode($dom, 'target', $translation->getTranslation()));
+            $segment->appendChild(static::createTextNode($dom, 'source', $translation->getOriginal()));
+            $segment->appendChild(static::createTextNode($dom, 'target', $translation->getTranslation()));
 
             foreach ($translation->getPluralTranslations() as $plural) {
                 if ($plural !== '') {
-                    $segment->appendChild(self::createTextNode($dom, 'target', $plural));
+                    $segment->appendChild(static::createTextNode($dom, 'target', $plural));
                 }
             }
 
@@ -92,7 +92,7 @@ class Xliff extends Generator implements GeneratorInterface
         return $dom->saveXML();
     }
 
-    private static function createTextNode(DOMDocument $dom, $name, $string)
+    protected static function createTextNode(DOMDocument $dom, $name, $string)
     {
         $node = $dom->createElement($name);
         $text = (preg_match('/[&<>]/', $string) === 1)
@@ -113,7 +113,7 @@ class Xliff extends Generator implements GeneratorInterface
     public static function getUnitID(Translation $translation)
     {
         foreach ($translation->getComments() as $comment) {
-            if (preg_match(self::UNIT_ID_REGEXP, $comment, $matches)) {
+            if (preg_match(static::UNIT_ID_REGEXP, $comment, $matches)) {
                 return $matches[1];
             }
         }

--- a/src/Generators/Yaml.php
+++ b/src/Generators/Yaml.php
@@ -24,7 +24,7 @@ class Yaml extends Generator implements GeneratorInterface
         $options += static::$options;
 
         return YamlDumper::dump(
-            self::toArray($translations, $options['includeHeaders']),
+            static::toArray($translations, $options['includeHeaders']),
             $options['inline'],
             $options['indent']
         );

--- a/src/Generators/YamlDictionary.php
+++ b/src/Generators/YamlDictionary.php
@@ -24,7 +24,7 @@ class YamlDictionary extends Generator implements GeneratorInterface
         $options += static::$options;
 
         return YamlDumper::dump(
-            self::toArray($translations, $options['includeHeaders']),
+            static::toArray($translations, $options['includeHeaders']),
             $options['inline'],
             $options['indent']
         );

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -6,16 +6,16 @@ use Gettext\Generators\PhpArray;
 
 class Translator extends BaseTranslator implements TranslatorInterface
 {
-    private $domain;
-    private $dictionary = [];
-    private $plurals = [];
+    protected $domain;
+    protected $dictionary = [];
+    protected $plurals = [];
 
     /**
      * Loads translation from a Translations instance, a file on an array.
      *
      * @param Translations|string|array $translations
      *
-     * @return self
+     * @return static
      */
     public function loadTranslations($translations)
     {
@@ -39,7 +39,7 @@ class Translator extends BaseTranslator implements TranslatorInterface
      *
      * @param string $domain
      *
-     * @return self
+     * @return static
      */
     public function defaultDomain($domain)
     {
@@ -209,7 +209,7 @@ class Translator extends BaseTranslator implements TranslatorInterface
         }
 
         if (!isset($this->plurals[$domain]['function'])) {
-            $code = self::fixTerseIfs($this->plurals[$domain]['code']);
+            $code = static::fixTerseIfs($this->plurals[$domain]['code']);
             $this->plurals[$domain]['function'] = eval("return function (\$n) { $code };");
         }
 
@@ -257,7 +257,7 @@ class Translator extends BaseTranslator implements TranslatorInterface
         $failure = $matches['failure'];
 
         // Go look for another terse if in the failure state.
-        $failure = self::fixTerseIfs($failure, true);
+        $failure = static::fixTerseIfs($failure, true);
         $code = $expression.' ? '.$success.' : '.$failure;
 
         if ($inner) {

--- a/src/Utils/CsvTrait.php
+++ b/src/Utils/CsvTrait.php
@@ -7,20 +7,20 @@ namespace Gettext\Utils;
  */
 trait CsvTrait
 {
-    private static $csvEscapeChar;
+    protected static $csvEscapeChar;
 
     /**
      * Check whether support the escape_char argument to fgetcsv/fputcsv or not
      *
      * @return bool
      */
-    private static function supportsCsvEscapeChar()
+    protected static function supportsCsvEscapeChar()
     {
-        if (self::$csvEscapeChar === null) {
-            self::$csvEscapeChar = version_compare(PHP_VERSION, '5.5.4') >= 0;
+        if (static::$csvEscapeChar === null) {
+            static::$csvEscapeChar = version_compare(PHP_VERSION, '5.5.4') >= 0;
         }
 
-        return self::$csvEscapeChar;
+        return static::$csvEscapeChar;
     }
 
     /**
@@ -29,9 +29,9 @@ trait CsvTrait
      *
      * @return array
      */
-    private static function fgetcsv($handle, $options)
+    protected static function fgetcsv($handle, $options)
     {
-        if (self::supportsCsvEscapeChar()) {
+        if (static::supportsCsvEscapeChar()) {
             return fgetcsv($handle, 0, $options['delimiter'], $options['enclosure'], $options['escape_char']);
         }
 
@@ -45,9 +45,9 @@ trait CsvTrait
      *
      * @return bool|int
      */
-    private static function fputcsv($handle, $fields, $options)
+    protected static function fputcsv($handle, $fields, $options)
     {
-        if (self::supportsCsvEscapeChar()) {
+        if (static::supportsCsvEscapeChar()) {
             return fputcsv($handle, $fields, $options['delimiter'], $options['enclosure'], $options['escape_char']);
         }
 

--- a/src/Utils/DictionaryTrait.php
+++ b/src/Utils/DictionaryTrait.php
@@ -20,12 +20,12 @@ trait DictionaryTrait
      *
      * @return array
      */
-    private static function toArray(Translations $translations, $includeHeaders)
+    protected static function toArray(Translations $translations, $includeHeaders)
     {
         $messages = [];
 
         if ($includeHeaders) {
-            $messages[''] = self::generateHeaders($translations);
+            $messages[''] = static::generateHeaders($translations);
         }
 
         foreach ($translations as $translation) {
@@ -45,11 +45,11 @@ trait DictionaryTrait
      * @param array        $messages
      * @param Translations $translations
      */
-    private static function fromArray(array $messages, Translations $translations)
+    protected static function fromArray(array $messages, Translations $translations)
     {
         foreach ($messages as $original => $translation) {
             if ($original === '') {
-                self::extractHeaders($translation, $translations);
+                static::extractHeaders($translation, $translations);
                 continue;
             }
 

--- a/src/Utils/FunctionsScanner.php
+++ b/src/Utils/FunctionsScanner.php
@@ -93,7 +93,7 @@ abstract class FunctionsScanner
      * @return array|null
      * @throws Exception
      */
-    private function deconstructArgs($function, $args)
+    protected function deconstructArgs($function, $args)
     {
         $domain = null;
         $context = null;

--- a/src/Utils/HeadersExtractorTrait.php
+++ b/src/Utils/HeadersExtractorTrait.php
@@ -17,19 +17,19 @@ trait HeadersExtractorTrait
      *
      * @return array
      */
-    private static function extractHeaders($headers, Translations $translations)
+    protected static function extractHeaders($headers, Translations $translations)
     {
         $headers = explode("\n", $headers);
         $currentHeader = null;
 
         foreach ($headers as $line) {
-            $line = self::convertString($line);
+            $line = static::convertString($line);
 
             if ($line === '') {
                 continue;
             }
 
-            if (self::isHeaderDefinition($line)) {
+            if (static::isHeaderDefinition($line)) {
                 $header = array_map('trim', explode(':', $line, 2));
                 $currentHeader = $header[0];
                 $translations->setHeader($currentHeader, $header[1]);
@@ -48,7 +48,7 @@ trait HeadersExtractorTrait
      *
      * @return bool
      */
-    private static function isHeaderDefinition($line)
+    protected static function isHeaderDefinition($line)
     {
         return (bool) preg_match('/^[\w-]+:/', $line);
     }

--- a/src/Utils/HeadersGeneratorTrait.php
+++ b/src/Utils/HeadersGeneratorTrait.php
@@ -16,7 +16,7 @@ trait HeadersGeneratorTrait
      *
      * @return string
      */
-    private static function generateHeaders(Translations $translations)
+    protected static function generateHeaders(Translations $translations)
     {
         $headers = '';
 

--- a/src/Utils/JsFunctionsScanner.php
+++ b/src/Utils/JsFunctionsScanner.php
@@ -56,7 +56,7 @@ class JsFunctionsScanner extends FunctionsScanner
                             }
                             break;
                     }
-                    
+
                     $prev = $char;
                     $char = $next;
                     $pos++;
@@ -172,7 +172,7 @@ class JsFunctionsScanner extends FunctionsScanner
                 case ')':
                     switch ($this->status()) {
                         case 'function':
-                            if (($argument = self::prepareArgument($buffer))) {
+                            if (($argument = static::prepareArgument($buffer))) {
                                 $bufferFunctions[0][2][] = $argument;
                             }
 
@@ -189,7 +189,7 @@ class JsFunctionsScanner extends FunctionsScanner
                 case ',':
                     switch ($this->status()) {
                         case 'function':
-                            if (($argument = self::prepareArgument($buffer))) {
+                            if (($argument = static::prepareArgument($buffer))) {
                                 $bufferFunctions[0][2][] = $argument;
                             }
 

--- a/src/Utils/MultidimensionalArrayTrait.php
+++ b/src/Utils/MultidimensionalArrayTrait.php
@@ -22,7 +22,7 @@ trait MultidimensionalArrayTrait
      *
      * @return array
      */
-    private static function toArray(Translations $translations, $includeHeaders, $forceArray = false)
+    protected static function toArray(Translations $translations, $includeHeaders, $forceArray = false)
     {
         $pluralForm = $translations->getPluralForms();
         $pluralSize = is_array($pluralForm) ? ($pluralForm[0] - 1) : null;
@@ -30,7 +30,7 @@ trait MultidimensionalArrayTrait
 
         if ($includeHeaders) {
             $messages[''] = [
-                '' => [self::generateHeaders($translations)],
+                '' => [static::generateHeaders($translations)],
             ];
         }
 
@@ -69,7 +69,7 @@ trait MultidimensionalArrayTrait
      * @param array        $messages
      * @param Translations $translations
      */
-    private static function fromArray(array $messages, Translations $translations)
+    protected static function fromArray(array $messages, Translations $translations)
     {
         if (!empty($messages['domain'])) {
             $translations->setDomain($messages['domain']);
@@ -82,7 +82,7 @@ trait MultidimensionalArrayTrait
         foreach ($messages['messages'] as $context => $contextTranslations) {
             foreach ($contextTranslations as $original => $value) {
                 if ($context === '' && $original === '') {
-                    self::extractHeaders(is_array($value) ? array_shift($value) : $value, $translations);
+                    static::extractHeaders(is_array($value) ? array_shift($value) : $value, $translations);
                     continue;
                 }
 

--- a/src/Utils/ParsedComment.php
+++ b/src/Utils/ParsedComment.php
@@ -48,7 +48,7 @@ class ParsedComment
      * @param string $value The PHP comment string.
      * @param int $line The line where the comment starts.
      *
-     * @return self The parsed comment.
+     * @return static The parsed comment.
      */
     public static function create($value, $line)
     {
@@ -69,7 +69,7 @@ class ParsedComment
         $lines = array_filter($lines);
         $value = implode(' ', $lines);
 
-        return new self($value, $line, $lastLine);
+        return new static($value, $line, $lastLine);
     }
 
     /**


### PR DESCRIPTION
The classes have a mixture of practices right now which make them very tricky to extend.

All classes seem to communicate they can be extended (i.e. they are not marked as `final`), but as most of them don't properly support late static binding (they use `self::` and `private` methods), extending them will lead to unexpected results and hard-to-diagnose bugs. `self::` and `private` should only be used in `final` classes, or, in more rare cases, when an extension should specifically _not_ have access to some part sof the base class.

The solution is to either mark all of them as `final` (provided there is an underlying interface), or make sure they properly support extension.

I've opted for the second option in this PR, for the following reasons:
- some classes were already changed from non-extensible to extensible in prior changes, so I suppose this is a wanted use case
- some classes have quite a bit of logic to them, and keeping them extensible avoids completely rewriting some of these

Related issue: #231