### PR TITLE
Mark `Merge` class as `final`

### DIFF
--- a/src/Merge.php
+++ b/src/Merge.php
@@ -5,7 +5,7 @@ namespace Gettext;
 /**
  * Static class with merge contants.
  */
-class Merge
+final class Merge
 {
     const ADD = 1;
     const REMOVE = 2;


### PR DESCRIPTION
The way the `Merge` class is constructed and used makes it difficult and useless to extend. Therefore, it should be marked as `final` to set proper expectations.

Related issue: #231