### PR TITLE
Remove direct references to class `Translation`

### DIFF
--- a/src/Extractors/Po.php
+++ b/src/Extractors/Po.php
@@ -23,7 +23,7 @@ class Po extends Extractor implements ExtractorInterface
         $lines = explode("\n", $string);
         $i = 0;
 
-        $translation = new Translation('', '');
+        $translation = $translations->createNewTranslation('', '');
 
         for ($n = count($lines); $i < $n; ++$i) {
             $line = trim($lines[$i]);
@@ -36,7 +36,7 @@ class Po extends Extractor implements ExtractorInterface
                     $translations[] = $translation;
                 }
 
-                $translation = new Translation('', '');
+                $translation = $translations->createNewTranslation('', '');
                 continue;
             }
 

--- a/src/Extractors/Xliff.php
+++ b/src/Extractors/Xliff.php
@@ -40,7 +40,7 @@ class Xliff extends Extractor implements ExtractorInterface
                         $targets[] = (string) $target;
                     }
 
-                    $translation = new Translation(null, (string) $segment->source);
+                    $translation = $translations->createNewTranslation(null, (string) $segment->source);
                     if (isset($unit['id'])) {
                         $unitId = (string) $unit['id'];
                         $translation->addComment("XLIFF_UNIT_ID: $unitId");

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -33,6 +33,21 @@ class Translation
     }
 
     /**
+     * Create a new instance of a Translation object.
+     *
+     * This is a factory method that will work even when Translation is extended.
+     *
+     * @param string $context  The context of the translation
+     * @param string $original The original string
+     * @param string $plural   The original plural string
+     * @return static New Translation instance
+     */
+    public function create($context, $original, $plural = '')
+    {
+        return new static($context, $original, $plural);
+    }
+
+    /**
      * Construct.
      *
      * @param string $context  The context of the translation

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -42,7 +42,7 @@ class Translation
      * @param string $plural   The original plural string
      * @return static New Translation instance
      */
-    public function create($context, $original, $plural = '')
+    public static function create($context, $original, $plural = '')
     {
         return new static($context, $original, $plural);
     }

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -120,13 +120,19 @@ class Translations extends ArrayObject
         ],
     ];
 
-    private $headers;
+    protected $headers;
+
+    protected $translationClass;
 
     /**
      * @see ArrayObject::__construct()
      */
-    public function __construct($input = [], $flags = 0, $iterator_class = 'ArrayIterator')
-    {
+    public function __construct(
+        $input = [],
+        $flags = 0,
+        $iterator_class = 'ArrayIterator',
+        $translationClass = 'Gettext\Translation'
+    ) {
         $this->headers = static::$options['defaultHeaders'];
 
         foreach (static::$options['defaultDateHeaders'] as $header) {
@@ -134,6 +140,8 @@ class Translations extends ArrayObject
         }
 
         $this->headers[self::HEADER_LANGUAGE] = '';
+
+        $this->translationClass = $translationClass;
 
         parent::__construct($input, $flags, $iterator_class);
     }
@@ -455,7 +463,7 @@ class Translations extends ArrayObject
      */
     public function insert($context, $original, $plural = '')
     {
-        return $this->offsetSet(null, new Translation($context, $original, $plural));
+        return $this->offsetSet(null, $this->createNewTranslation($context, $original, $plural));
     }
 
     /**
@@ -472,5 +480,19 @@ class Translations extends ArrayObject
         Merge::mergeTranslations($translations, $this, $options);
 
         return $this;
+    }
+
+    /**
+     * Create a new instance of a Translation object.
+     *
+     * @param string $context  The context of the translation
+     * @param string $original The original string
+     * @param string $plural   The original plural string
+     * @return Translation New Translation instance
+     */
+    public function createNewTranslation($context, $original, $plural = '')
+    {
+        $factoryMethod = "{$this->translationClass}::create";
+        return $factoryMethod($context, $original, $plural);
     }
 }

--- a/src/Translations.php
+++ b/src/Translations.php
@@ -492,7 +492,7 @@ class Translations extends ArrayObject
      */
     public function createNewTranslation($context, $original, $plural = '')
     {
-        $factoryMethod = "{$this->translationClass}::create";
-        return $factoryMethod($context, $original, $plural);
+        $class = $this->translationClass;
+        return $class::create($context, $original, $plural);
     }
 }


### PR DESCRIPTION
To make the class `Translation` extensible without introducing bugs, the `Translations` class was now adapted to accept a class name of a Translation object to use.

This makes sure that when you extend `Translation`, you can enforce use of that extension even when `Translations` needs to create new instances of it.

`Translation` also has a `create()` method now so that when you have an instance of a translation you can easily create a new one without needing to know the exact class name.

Related issue: #231