### PR TITLE
Make it easier to extend scanning classes

### DIFF
--- a/src/Extractors/JsCode.php
+++ b/src/Extractors/JsCode.php
@@ -4,7 +4,7 @@ namespace Gettext\Extractors;
 
 use Exception;
 use Gettext\Translations;
-use Gettext\Utils\JsFunctionsScanner;
+use Gettext\Utils\FunctionsScanner;
 
 /**
  * Class to get gettext strings from javascript files.
@@ -36,6 +36,8 @@ class JsCode extends Extractor implements ExtractorInterface, ExtractorMultiInte
         ],
     ];
 
+    protected static $functionsScannerClass = 'Gettext\Utils\JsFunctionsScanner';
+
     /**
      * @inheritdoc
      * @throws Exception
@@ -53,7 +55,8 @@ class JsCode extends Extractor implements ExtractorInterface, ExtractorMultiInte
     {
         $options += static::$options;
 
-        $functions = new JsFunctionsScanner($string);
+        /** @var FunctionsScanner $functions */
+        $functions = new static::$functionsScannerClass($string);
         $functions->saveGettextFunctions($translations, $options);
     }
 

--- a/src/Extractors/Mo.php
+++ b/src/Extractors/Mo.php
@@ -15,12 +15,15 @@ class Mo extends Extractor implements ExtractorInterface
     const MAGIC2 = -569244523;
     const MAGIC3 = 2500072158;
 
+    protected static $stringReaderClass = 'Gettext\Utils\StringReader';
+
     /**
      * {@inheritdoc}
      */
     public static function fromString($string, Translations $translations, array $options = [])
     {
-        $stream = new StringReader($string);
+        /** @var StringReader $stream */
+        $stream = new static::$stringReaderClass($string);
         $magic = self::readInt($stream, 'V');
 
         if (($magic === self::MAGIC1) || ($magic === self::MAGIC3)) { //to make sure it works for 64-bit platforms

--- a/src/Extractors/PhpCode.php
+++ b/src/Extractors/PhpCode.php
@@ -4,7 +4,7 @@ namespace Gettext\Extractors;
 
 use Exception;
 use Gettext\Translations;
-use Gettext\Utils\PhpFunctionsScanner;
+use Gettext\Utils\FunctionsScanner;
 
 /**
  * Class to get gettext strings from php files returning arrays.
@@ -42,6 +42,8 @@ class PhpCode extends Extractor implements ExtractorInterface, ExtractorMultiInt
         ],
     ];
 
+    protected static $functionsScannerClass = 'Gettext\Utils\PhpFunctionsScanner';
+
     /**
      * {@inheritdoc}
      * @throws Exception
@@ -59,7 +61,8 @@ class PhpCode extends Extractor implements ExtractorInterface, ExtractorMultiInt
     {
         $options += static::$options;
 
-        $functions = new PhpFunctionsScanner($string);
+        /** @var FunctionsScanner $functions */
+        $functions = new static::$functionsScannerClass($string);
 
         if ($options['extractComments'] !== false) {
             $functions->enableCommentsExtraction($options['extractComments']);

--- a/src/Extractors/VueJs.php
+++ b/src/Extractors/VueJs.php
@@ -9,7 +9,7 @@ use DOMElement;
 use DOMNode;
 use Exception;
 use Gettext\Translations;
-use Gettext\Utils\JsFunctionsScanner;
+use Gettext\Utils\FunctionsScanner;
 
 /**
  * Class to get gettext strings from VueJS template files.
@@ -40,6 +40,8 @@ class VueJs extends Extractor implements ExtractorInterface, ExtractorMultiInter
             'noop__' => 'noop',
         ],
     ];
+
+    protected static $functionsScannerClass = 'Gettext\Utils\JsFunctionsScanner';
 
     /**
      * @inheritDoc
@@ -185,7 +187,8 @@ class VueJs extends Extractor implements ExtractorInterface, ExtractorMultiInter
         array $options = [],
         $lineOffset = 0
     ) {
-        $functions = new JsFunctionsScanner($scriptContents);
+        /** @var FunctionsScanner $functions */
+        $functions = new static::$functionsScannerClass($scriptContents);
         $options['lineOffset'] = $lineOffset;
         $functions->saveGettextFunctions($translations, $options);
     }


### PR DESCRIPTION
The FunctionsScanner and StringReader classes are directly referenced in the pieces of logic that use them. If you want to extend one of these, you have to duplicate a big chunk of logic just to change the class reference for the `new` call.

This PR extracts the class name into a protected static property that can be changed in extending classes, to avoid the need to copy-paste big chunks of logic when they need to be changed.

Related issue: #231